### PR TITLE
docs: add module-level docstrings across package

### DIFF
--- a/src/rs_embed/__init__.py
+++ b/src/rs_embed/__init__.py
@@ -1,3 +1,12 @@
+"""rs-embed — location embeddings from remote-sensing imagery.
+
+This top-level package re-exports the public API surface so that users can
+write ``from rs_embed import Model, BBox`` without reaching into subpackages.
+
+See :mod:`rs_embed.api` for the function-based API and :class:`rs_embed.Model`
+for the class-based (stateful) interface.
+"""
+
 from .core.specs import (
     BBox,
     PointBuffer,

--- a/src/rs_embed/__main__.py
+++ b/src/rs_embed/__main__.py
@@ -1,3 +1,4 @@
+"""Allow ``python -m rs_embed`` to invoke the CLI."""
 from __future__ import annotations
 
 from .cli import main

--- a/src/rs_embed/api.py
+++ b/src/rs_embed/api.py
@@ -1,25 +1,33 @@
-"""Public API entry points for rs-embed.
+"""Public Facade and Entry Point.
 
-This module is the boundary between user-facing functions and the internal
-pipeline stack:
+This module is the single boundary between callers and the internal pipeline
+stack.  It should contain **no** heavy execution logic — only configuration
+and delegation.
 
-- API layer: argument normalization and user-friendly defaults.
-- Pipeline layer: batch orchestration (prefetch -> inference -> write).
-- Tools/providers/embedders: low-level execution details.
+Responsibilities
+----------------
+1. **Validation** — ensure all input Specs (Spatial, Temporal, Output) are
+   valid before any processing begins.
+2. **Normalisation** — convert user-friendly strings (e.g. ``"sentinel-2"``,
+   ``"cuda"``) into strict internal objects.
+3. **Context Resolution** — route each request to the correct backend
+   (Provider vs. Precomputed) and device.
+4. **Delegation** — instantiate the appropriate Pipeline or Embedder and
+   hand off execution.
 
 Flow summary
 ------------
-1. Validate and normalize user inputs/specs.
-2. Resolve request context (model/backend/device/sensor/input prep).
-3. Execute single/batch embedding, or delegate batch export to
-    :class:`BatchExporter`.
+1. Validate and normalise user inputs / specs.
+2. Resolve request context (model / backend / device / sensor / input prep).
+3. Execute single / batch embedding, or delegate batch export to
+   :class:`BatchExporter`.
 
 Backward compatibility
 ----------------------
 Some tests and downstream integrations monkeypatch symbols on ``rs_embed.api``.
 For batch export, those hook symbols are mirrored into pipeline module globals
-via ``_sync_export_pipeline_hooks`` so monkeypatch behavior remains stable after
-the pipeline refactor.
+via ``_sync_export_pipeline_hooks`` so monkeypatch behaviour remains stable
+after the pipeline refactor.
 """
 
 from __future__ import annotations

--- a/src/rs_embed/cli.py
+++ b/src/rs_embed/cli.py
@@ -1,3 +1,13 @@
+"""Command-Line Interface.
+
+Provides ``python -m rs_embed`` (via :mod:`rs_embed.__main__`) with the
+following subcommands:
+
+- ``inspect-gee`` — download a patch from Google Earth Engine and print an
+  input-inspection report (no model run).
+- ``export-npz``  — export raw inputs and/or embeddings for one or more
+  models into ``.npz`` + JSON manifest files.
+"""
 from __future__ import annotations
 
 import argparse

--- a/src/rs_embed/core/__init__.py
+++ b/src/rs_embed/core/__init__.py
@@ -1,0 +1,17 @@
+"""
+Domain Definitions and Data Contracts.
+
+This module defines the immutable "Nouns" of the system:
+
+- **Specs**: Data contracts (``SpatialSpec``, ``SensorSpec``, ``OutputSpec``,
+  ``TemporalSpec``, ``InputPrepSpec``).
+- **Types**: Return types (``Embedding``) and configuration hints
+  (``ExportConfig``, ``ModelConfig``).
+- **Errors**: Custom exception hierarchy (``SpecError``, ``ProviderError``).
+
+Rules
+-----
+- **Pure data only** — no processing logic, no heavy imports.
+- **Zero cross-package dependencies** — this module must *never* import from
+  ``pipelines``, ``providers``, ``embedders``, or ``tools``.
+"""

--- a/src/rs_embed/embedders/__init__.py
+++ b/src/rs_embed/embedders/__init__.py
@@ -1,3 +1,21 @@
+"""
+Model Implementations (Plugins).
+
+This module contains the specific inference logic for each supported AI model.
+
+To add a new model:
+
+1. Create a new file (e.g., ``my_model.py``).
+2. Inherit from ``rs_embed.embedders.base.EmbedderBase``.
+3. Implement ``get_embedding()``.
+
+Rules
+-----
+- Models should be self-contained.
+- Only inference logic belongs here — no training code.
+- Lazy-loading: embedder classes are imported on first access via
+  ``__getattr__`` so unused models incur no startup cost.
+"""
 from __future__ import annotations
 
 import importlib

--- a/src/rs_embed/pipelines/__init__.py
+++ b/src/rs_embed/pipelines/__init__.py
@@ -1,4 +1,21 @@
-"""Engine layer: parallel execution, inference, and orchestration."""
+"""
+Workflow Orchestration and Execution.
+
+This module contains the stateful "Verbs" of the system.  It wires together
+Providers (data) and Embedders (models) to perform work.
+
+Key Components
+--------------
+- ``InferenceEngine``  — manages model loading, threading, and batch inference.
+- ``BatchExporter``    — orchestrates the end-to-end flow
+  (Prefetch → Tile → Infer → Save).
+- ``ParallelRunner``   — handles concurrency, retries, and error suppression.
+- ``PrefetchManager``  — pre-downloads imagery ahead of inference.
+- ``CheckpointManager`` — tracks progress so interrupted jobs can resume.
+
+Use this module for high-level process control, performance optimisation, and
+loop management.
+"""
 
 from .runner import ParallelRunner, run_with_retry
 from .inference import InferenceEngine

--- a/src/rs_embed/providers/__init__.py
+++ b/src/rs_embed/providers/__init__.py
@@ -1,3 +1,18 @@
+"""
+Data Source Adapters.
+
+This module handles fetching raw imagery from external services
+(Google Earth Engine, Sentinel Hub, local files, etc.).
+
+To add a new data source:
+
+1. Inherit from ``rs_embed.providers.base.ProviderBase``.
+2. Implement ``fetch_array_chw()`` to return a standardised NumPy array
+   shaped ``(C, H, W)``.
+3. Handle authentication and networking internally.
+
+Built-in providers are lazy-loaded so optional dependencies stay optional.
+"""
 from __future__ import annotations
 
 import importlib

--- a/src/rs_embed/tools/__init__.py
+++ b/src/rs_embed/tools/__init__.py
@@ -1,1 +1,20 @@
-# rs_embed.tools — stateless utility modules (formerly internal/api/)
+"""
+Stateless Utilities and Helper Functions.
+
+A collection of pure functions for generic tasks.  Code here must be
+stateless (inputs -> outputs) and reusable across different pipelines.
+
+Categories
+----------
+- **Tiling** (``tiling``) — geometric math for cutting images into patches.
+- **Inspection** (``inspection``) — histogram calculation and data-quality checks.
+- **Serialization** (``serialization``) — JSON / NPZ saving and hashing.
+- **Temporal** (``temporal``) — date parsing and time-range helpers.
+- **Normalization** (``normalization``) — value scaling and string normalisation.
+- **Checkpoints** (``checkpoint_utils``) — resume-friendly progress tracking.
+- **Manifests** (``manifest``) — metadata bookkeeping for export runs.
+- **Output** (``output``) — path and directory helpers for saved artefacts.
+- **Progress** (``progress``) — progress-bar wrappers.
+- **Runtime** (``runtime``) — environment detection (device, memory, threads).
+- **Model Defaults** (``model_defaults``) — canonical per-model fallback configs.
+"""


### PR DESCRIPTION
Add clarifying docstrings to all subpackage __init__.py files and top-level modules to document each module's role, rules, and extension points.

- core/__init__.py: new file (domain definitions, data contracts)
- pipelines/__init__.py: workflow orchestration and execution
- embedders/__init__.py: model plugin architecture
- providers/__init__.py: data source adapters
- tools/__init__.py: stateless utilities
- api.py: merged public facade responsibilities with existing docs
- cli.py: CLI architecture and subcommands
- __init__.py: package overview
- __main__.py: entry-point note