### PR TITLE
refactor: clean up export_batch API — require ExportTarget and ExportConfig

### DIFF
--- a/src/rs_embed/api.py
+++ b/src/rs_embed/api.py
@@ -26,6 +26,7 @@ Flow summary
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 from .core.embedding import Embedding
@@ -56,9 +57,6 @@ from .core.validation import (
 from .embedders.catalog import MODEL_ALIASES, MODEL_SPECS
 from .tools.export_requests import (
     maybe_return_completed_combined_resume as _maybe_return_completed_combined_resume,
-)
-from .tools.export_requests import (
-    normalize_export_config as _normalize_export_config,
 )
 from .tools.export_requests import (
     normalize_export_format as _normalize_export_format,
@@ -339,13 +337,8 @@ def export_batch(
     spatials: list[SpatialSpec],
     temporal: TemporalSpec | None,
     models: list[str | ExportModelRequest],
-    target: ExportTarget | None = None,
-    config: ExportConfig | None = None,
-    out: str | None = None,
-    layout: str | None = None,
-    out_dir: str | None = None,
-    out_path: str | None = None,
-    names: list[str] | None = None,
+    target: ExportTarget,
+    config: ExportConfig = ExportConfig(),
     backend: str = "auto",
     device: str = "auto",
     output: OutputSpec = OutputSpec.pooled(),
@@ -355,22 +348,6 @@ def export_batch(
     per_model_sensors: dict[str, SensorSpec] | None = None,
     per_model_fetches: dict[str, FetchSpec] | None = None,
     per_model_modalities: dict[str, str] | None = None,
-    format: str = "npz",
-    save_inputs: bool = True,
-    save_embeddings: bool = True,
-    save_manifest: bool = True,
-    fail_on_bad_input: bool = False,
-    chunk_size: int = 16,
-    infer_batch_size: int | None = None,
-    num_workers: int = 8,
-    continue_on_error: bool = False,
-    max_retries: int = 0,
-    retry_backoff_s: float = 0.0,
-    async_write: bool = True,
-    writer_workers: int = 2,
-    resume: bool = False,
-    show_progress: bool = True,
-    input_prep: InputPrepSpec | str | None = "resize",
 ) -> Any:
     """Export inputs + embeddings for many spatials and many models.
 
@@ -385,21 +362,12 @@ def export_batch(
         Optional temporal filter applied to all spatial requests.
     models : list[str | ExportModelRequest]
         Model identifiers or per-model request objects.
-    target : ExportTarget or None
-        Preferred output target object for new code.
-    config : ExportConfig or None
-        Preferred export runtime configuration object for new code.
-    out : str or None
-        Legacy output path hint. Combined layout when file-like, per-item
-        layout when directory-like.
-    layout : str or None
-        Explicit layout override (``"combined"`` or ``"per_item"``).
-    out_dir : str or None
-        Directory path for per-item exports.
-    out_path : str or None
-        File path for combined exports.
-    names : list[str] or None
-        Legacy names aligned with ``spatials`` for per-item outputs.
+    target : ExportTarget
+        Output destination: use :meth:`ExportTarget.per_item` for per-item
+        directory exports or :meth:`ExportTarget.combined` for a single file.
+    config : ExportConfig
+        Runtime configuration (format, workers, resume, etc.).
+        Defaults to :class:`ExportConfig` with all defaults applied.
     backend : str
         Backend/provider selector.
     device : str
@@ -421,11 +389,6 @@ def export_batch(
         combined with sensor overrides for the same model.
     per_model_modalities : dict[str, str] or None
         Optional per-model modality overrides keyed by model name.
-    format / save_* / fail_on_bad_input / chunk_size / infer_batch_size /
-    num_workers / continue_on_error / max_retries / retry_backoff_s /
-    async_write / writer_workers / resume / show_progress / input_prep
-        Legacy config-style keyword arguments. New code should prefer
-        ``config=ExportConfig(...)``.
 
     Returns
     -------
@@ -448,36 +411,13 @@ def export_batch(
     backend_n = _normalize_backend_name(backend)
     device_n = _normalize_device_name(device)
 
-    export_config = _normalize_export_config(
-        config=config,
-        format=format,
-        save_inputs=save_inputs,
-        save_embeddings=save_embeddings,
-        save_manifest=save_manifest,
-        fail_on_bad_input=fail_on_bad_input,
-        chunk_size=chunk_size,
-        infer_batch_size=infer_batch_size,
-        num_workers=num_workers,
-        continue_on_error=continue_on_error,
-        max_retries=max_retries,
-        retry_backoff_s=retry_backoff_s,
-        async_write=async_write,
-        writer_workers=writer_workers,
-        resume=resume,
-        show_progress=show_progress,
-        input_prep=input_prep,
-    )
-    _fmt, ext = _normalize_export_format(export_config.format)
+    fmt, ext = _normalize_export_format(config.format)
+    export_config = replace(config, format=fmt)
 
     export_target = _normalize_export_target(
         n_spatials=len(spatials),
         ext=ext,
         target=target,
-        out=out,
-        layout=layout,
-        out_dir=out_dir,
-        out_path=out_path,
-        names=names,
     )
 
     _validate_spatial_list(spatials=spatials, temporal=temporal, output=output)

--- a/src/rs_embed/export.py
+++ b/src/rs_embed/export.py
@@ -6,9 +6,11 @@
 from __future__ import annotations
 
 import os
+from dataclasses import replace
 from typing import Any
 
-from .core.specs import FetchSpec, InputPrepSpec, OutputSpec, SensorSpec, SpatialSpec, TemporalSpec
+from .core.specs import FetchSpec, OutputSpec, SensorSpec, SpatialSpec, TemporalSpec
+from .core.types import ExportConfig, ExportTarget
 
 
 def export_npz(
@@ -24,17 +26,14 @@ def export_npz(
     fetch: FetchSpec | None = None,
     per_model_sensors: dict[str, SensorSpec] | None = None,
     per_model_fetches: dict[str, FetchSpec] | None = None,
-    save_inputs: bool = True,
-    save_embeddings: bool = True,
-    save_manifest: bool = True,
-    fail_on_bad_input: bool = False,
-    infer_batch_size: int | None = None,
-    continue_on_error: bool = False,
-    max_retries: int = 0,
-    retry_backoff_s: float = 0.0,
-    input_prep: InputPrepSpec | str | None = "resize",
+    config: ExportConfig = ExportConfig(),
 ) -> dict[str, Any]:
-    """Export inputs + embeddings for one spatial query to a single `.npz`."""
+    """Export inputs + embeddings for one spatial query to a single `.npz`.
+
+    The output format is always ``"npz"`` regardless of any ``config.format``
+    value passed in; ``config`` controls all other runtime settings (workers,
+    resume, show_progress, input_prep, etc.).
+    """
     from .api import export_batch as _api_export_batch
 
     os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
@@ -45,7 +44,8 @@ def export_npz(
         spatials=[spatial],
         temporal=temporal,
         models=models,
-        out_path=out_path,
+        target=ExportTarget.combined(out_path),
+        config=replace(config, format="npz"),
         backend=backend,
         device=device,
         output=output,
@@ -53,14 +53,4 @@ def export_npz(
         fetch=fetch,
         per_model_sensors=per_model_sensors,
         per_model_fetches=per_model_fetches,
-        format="npz",
-        save_inputs=save_inputs,
-        save_embeddings=save_embeddings,
-        save_manifest=save_manifest,
-        fail_on_bad_input=fail_on_bad_input,
-        infer_batch_size=infer_batch_size,
-        continue_on_error=continue_on_error,
-        max_retries=max_retries,
-        retry_backoff_s=retry_backoff_s,
-        input_prep=input_prep,
     )

--- a/src/rs_embed/tools/export_requests.py
+++ b/src/rs_embed/tools/export_requests.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import os
-from dataclasses import replace
 
 from ..core.errors import ModelError
 from ..core.registry import get_embedder_cls
-from ..core.specs import FetchSpec, InputPrepSpec, OutputSpec, SensorSpec, SpatialSpec, TemporalSpec
+from ..core.specs import FetchSpec, OutputSpec, SensorSpec, SpatialSpec, TemporalSpec
 from ..core.types import (
     ExportConfig,
     ExportLayout,
@@ -21,15 +20,6 @@ from .normalization import _resolve_embedding_api_backend, normalize_model_name
 from .runtime import require_model_config_support
 
 
-def normalize_export_layout(layout: str) -> ExportLayout:
-    layout_n = str(layout).strip().lower().replace("-", "_")
-    if layout_n in {"combined", "single_file", "file"}:
-        return ExportLayout.COMBINED
-    if layout_n in {"per_item", "dir", "directory"}:
-        return ExportLayout.PER_ITEM
-    raise ModelError(f"Unsupported export layout: {layout!r}. Supported: 'combined', 'per_item'.")
-
-
 def normalize_export_format(format_name: str) -> tuple[str, str]:
     fmt = str(format_name).strip().lower()
     from ..writers import SUPPORTED_FORMATS, get_extension
@@ -41,159 +31,30 @@ def normalize_export_format(format_name: str) -> tuple[str, str]:
     return fmt, get_extension(fmt)
 
 
-def _resolve_export_batch_target(
-    *,
-    n_spatials: int,
-    ext: str,
-    out: str | None,
-    layout: str | None,
-    out_dir: str | None,
-    out_path: str | None,
-    names: list[str] | None,
-) -> ExportTarget:
-    if (out is not None) or (layout is not None):
-        if out is None or layout is None:
-            raise ModelError("Provide both out and layout when using the decoupled output API.")
-        if out_dir is not None or out_path is not None:
-            raise ModelError("Use either out+layout or out_dir/out_path, not both.")
-        layout_enum = normalize_export_layout(layout)
-        if layout_enum == ExportLayout.COMBINED:
-            out_path = out
-        else:
-            out_dir = out
-
-    if out_dir is None and out_path is None:
-        raise ModelError("export_batch requires out_dir or out_path.")
-    if out_dir is not None and out_path is not None:
-        raise ModelError("Provide only one of out_dir or out_path.")
-
-    if out_path is not None:
-        out_file = out_path if out_path.endswith(ext) else (out_path + ext)
-        return ExportTarget(layout=ExportLayout.COMBINED, out_file=out_file)
-
-    assert out_dir is not None
-    point_names = names if names is not None else [f"p{i:05d}" for i in range(n_spatials)]
-    if len(point_names) != n_spatials:
-        raise ModelError("names must have the same length as spatials.")
-    return ExportTarget(layout=ExportLayout.PER_ITEM, out_dir=out_dir, names=point_names)
-
-
 def normalize_export_target(
     *,
     n_spatials: int,
     ext: str,
-    target: ExportTarget | None,
-    out: str | None,
-    layout: str | None,
-    out_dir: str | None,
-    out_path: str | None,
-    names: list[str] | None,
+    target: ExportTarget,
 ) -> ExportTarget:
-    if target is not None:
-        if not isinstance(target, ExportTarget):
-            raise ModelError("target must be an ExportTarget instance.")
-        if any(v is not None for v in (out, layout, out_dir, out_path, names)):
-            raise ModelError(
-                "Use either target=ExportTarget(...) or legacy out/layout/out_dir/out_path/names arguments, not both."
-            )
-        if target.layout == ExportLayout.COMBINED:
-            if not target.out_file:
-                raise ModelError("ExportTarget.COMBINED requires out_file.")
-            out_file = target.out_file if target.out_file.endswith(ext) else (target.out_file + ext)
-            return ExportTarget.combined(out_file)
-        if target.layout == ExportLayout.PER_ITEM:
-            if not target.out_dir:
-                raise ModelError("ExportTarget.PER_ITEM requires out_dir.")
-            point_names = (
-                target.names
-                if target.names is not None
-                else [f"p{i:05d}" for i in range(n_spatials)]
-            )
-            if len(point_names) != n_spatials:
-                raise ModelError("target.names must have the same length as spatials.")
-            return ExportTarget.per_item(target.out_dir, names=point_names)
-        raise ModelError(f"Unsupported ExportTarget layout: {target.layout!r}.")
-
-    return _resolve_export_batch_target(
-        n_spatials=n_spatials,
-        ext=ext,
-        out=out,
-        layout=layout,
-        out_dir=out_dir,
-        out_path=out_path,
-        names=names,
-    )
-
-
-def normalize_export_config(
-    *,
-    config: ExportConfig | None,
-    format: str,
-    save_inputs: bool,
-    save_embeddings: bool,
-    save_manifest: bool,
-    fail_on_bad_input: bool,
-    chunk_size: int,
-    infer_batch_size: int | None,
-    num_workers: int,
-    continue_on_error: bool,
-    max_retries: int,
-    retry_backoff_s: float,
-    async_write: bool,
-    writer_workers: int,
-    resume: bool,
-    show_progress: bool,
-    input_prep: InputPrepSpec | str | None,
-) -> ExportConfig:
-    default_cfg = ExportConfig()
-    legacy_config_used = any(
-        [
-            format != default_cfg.format,
-            save_inputs != default_cfg.save_inputs,
-            save_embeddings != default_cfg.save_embeddings,
-            save_manifest != default_cfg.save_manifest,
-            fail_on_bad_input != default_cfg.fail_on_bad_input,
-            chunk_size != default_cfg.chunk_size,
-            infer_batch_size != default_cfg.infer_batch_size,
-            num_workers != default_cfg.num_workers,
-            continue_on_error != default_cfg.continue_on_error,
-            max_retries != default_cfg.max_retries,
-            retry_backoff_s != default_cfg.retry_backoff_s,
-            async_write != default_cfg.async_write,
-            writer_workers != default_cfg.writer_workers,
-            resume != default_cfg.resume,
-            show_progress != default_cfg.show_progress,
-            input_prep != default_cfg.input_prep,
-        ]
-    )
-    if config is not None and legacy_config_used:
-        raise ModelError(
-            "Use either config=ExportConfig(...) or legacy export config keyword arguments, not both."
+    if not isinstance(target, ExportTarget):
+        raise ModelError("target must be an ExportTarget instance.")
+    if target.layout == ExportLayout.COMBINED:
+        if not target.out_file:
+            raise ModelError("ExportTarget.COMBINED requires out_file.")
+        out_file = target.out_file if target.out_file.endswith(ext) else (target.out_file + ext)
+        return ExportTarget.combined(out_file)
+    if target.layout == ExportLayout.PER_ITEM:
+        if not target.out_dir:
+            raise ModelError("ExportTarget.PER_ITEM requires out_dir.")
+        point_names = (
+            target.names if target.names is not None else [f"p{i:05d}" for i in range(n_spatials)]
         )
+        if len(point_names) != n_spatials:
+            raise ModelError("target.names must have the same length as spatials.")
+        return ExportTarget.per_item(target.out_dir, names=point_names)
+    raise ModelError(f"Unsupported ExportTarget layout: {target.layout!r}.")
 
-    if config is not None:
-        fmt, _ext = normalize_export_format(config.format)
-        return replace(config, format=fmt)
-
-    fmt, _ext = normalize_export_format(format)
-    return ExportConfig(
-        format=fmt,
-        save_inputs=save_inputs,
-        save_embeddings=save_embeddings,
-        save_manifest=save_manifest,
-        fail_on_bad_input=fail_on_bad_input,
-        chunk_size=chunk_size,
-        infer_batch_size=infer_batch_size,
-        num_workers=num_workers,
-        continue_on_error=continue_on_error,
-        max_retries=max_retries,
-        retry_backoff_s=retry_backoff_s,
-        async_write=async_write,
-        writer_workers=writer_workers,
-        resume=resume,
-        show_progress=show_progress,
-        input_prep=input_prep,
-    )
 
 
 def resolve_export_model_configs(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -563,7 +563,12 @@ def test_export_batch_empty_spatials():
     from rs_embed.api import export_batch
 
     with pytest.raises(ModelError, match="non-empty"):
-        export_batch(spatials=[], temporal=_TEMPORAL, models=["mock_model"], out_dir="/tmp")
+        export_batch(
+            spatials=[],
+            temporal=_TEMPORAL,
+            models=["mock_model"],
+            target=ExportTarget.per_item("/tmp"),
+        )
 
 
 def test_export_batch_rejects_non_list_spatials():
@@ -575,58 +580,27 @@ def test_export_batch_rejects_non_list_spatials():
             spatials=(_SPATIAL,),
             temporal=_TEMPORAL,
             models=["mock_model"],
-            out_dir="/tmp",
+            target=ExportTarget.per_item("/tmp"),
         )
 
     with pytest.raises(ModelError, match="non-empty"):
-        export_batch(spatials=_SPATIAL, temporal=_TEMPORAL, models=["mock_model"], out_dir="/tmp")
+        export_batch(
+            spatials=_SPATIAL,
+            temporal=_TEMPORAL,
+            models=["mock_model"],
+            target=ExportTarget.per_item("/tmp"),
+        )
 
 
 def test_export_batch_empty_models():
     from rs_embed.api import export_batch
 
     with pytest.raises(ModelError, match="non-empty"):
-        export_batch(spatials=[_SPATIAL], temporal=_TEMPORAL, models=[], out_dir="/tmp")
-
-
-def test_export_batch_no_output_arg():
-    from rs_embed.api import export_batch
-
-    with pytest.raises(ModelError, match="out_dir or out_path"):
-        export_batch(spatials=[_SPATIAL], temporal=_TEMPORAL, models=["mock_model"])
-
-
-def test_export_batch_both_output_args():
-    from rs_embed.api import export_batch
-
-    with pytest.raises(ModelError, match="only one"):
         export_batch(
             spatials=[_SPATIAL],
             temporal=_TEMPORAL,
-            models=["mock_model"],
-            out_dir="/tmp/a",
-            out_path="/tmp/b.npz",
-        )
-
-
-def test_export_batch_decoupled_output_api_requires_out_and_layout():
-    from rs_embed.api import export_batch
-
-    with pytest.raises(ModelError, match="both out and layout"):
-        export_batch(spatials=[_SPATIAL], temporal=_TEMPORAL, models=["mock_model"], out="/tmp/x")
-
-
-def test_export_batch_decoupled_output_api_disallows_mixing_with_legacy_args():
-    from rs_embed.api import export_batch
-
-    with pytest.raises(ModelError, match="either out\\+layout or out_dir/out_path"):
-        export_batch(
-            spatials=[_SPATIAL],
-            temporal=_TEMPORAL,
-            models=["mock_model"],
-            out="/tmp/x",
-            layout="combined",
-            out_path="/tmp/y.npz",
+            models=[],
+            target=ExportTarget.per_item("/tmp"),
         )
 
 
@@ -638,8 +612,8 @@ def test_export_batch_unsupported_format():
             spatials=[_SPATIAL],
             temporal=_TEMPORAL,
             models=["mock_model"],
-            out_dir="/tmp",
-            format="parquet",
+            target=ExportTarget.per_item("/tmp"),
+            config=ExportConfig(format="parquet"),
         )
 
 
@@ -651,12 +625,14 @@ def test_export_batch_accepts_netcdf_format(tmp_path):
         spatials=[_SPATIAL],
         temporal=_TEMPORAL,
         models=["mock_model"],
-        out_dir=str(tmp_path),
-        format="netcdf",
+        target=ExportTarget.per_item(str(tmp_path)),
+        config=ExportConfig(
+            format="netcdf",
+            save_inputs=False,
+            save_embeddings=True,
+            save_manifest=False,
+        ),
         backend="local",
-        save_inputs=False,
-        save_embeddings=True,
-        save_manifest=False,
     )
     assert len(results) == 1
     nc_file = tmp_path / "p00000.nc"
@@ -671,43 +647,70 @@ def test_export_batch_names_length_mismatch(tmp_path):
             spatials=[_SPATIAL, _SPATIAL],
             temporal=_TEMPORAL,
             models=["mock_model"],
-            out_dir=str(tmp_path),
-            names=["only_one"],
+            target=ExportTarget.per_item(str(tmp_path), names=["only_one"]),
         )
 
 
-def test_export_batch_decoupled_layout_per_item(tmp_path):
+def test_export_batch_combined_target_requires_out_file():
+    from rs_embed.api import export_batch
+    from rs_embed.core.types import ExportLayout
+
+    with pytest.raises(ModelError, match="requires out_file"):
+        export_batch(
+            spatials=[_SPATIAL],
+            temporal=_TEMPORAL,
+            models=["mock_model"],
+            target=ExportTarget(layout=ExportLayout.COMBINED),
+        )
+
+
+def test_export_batch_per_item_target_requires_out_dir():
+    from rs_embed.api import export_batch
+    from rs_embed.core.types import ExportLayout
+
+    with pytest.raises(ModelError, match="requires out_dir"):
+        export_batch(
+            spatials=[_SPATIAL],
+            temporal=_TEMPORAL,
+            models=["mock_model"],
+            target=ExportTarget(layout=ExportLayout.PER_ITEM),
+        )
+
+
+def test_export_batch_per_item_layout(tmp_path):
     from rs_embed.api import export_batch
 
     export_batch(
         spatials=[_SPATIAL],
         temporal=_TEMPORAL,
         models=["mock_model"],
-        out=str(tmp_path / "dir_out"),
-        layout="per_item",
+        target=ExportTarget.per_item(str(tmp_path / "dir_out")),
+        config=ExportConfig(
+            save_inputs=False,
+            save_embeddings=True,
+            save_manifest=False,
+            show_progress=False,
+        ),
         backend="local",
-        save_inputs=False,
-        save_embeddings=True,
-        save_manifest=False,
-        show_progress=False,
     )
     assert (tmp_path / "dir_out" / "p00000.npz").exists()
 
 
-def test_export_batch_decoupled_layout_combined(tmp_path):
+def test_export_batch_combined_layout(tmp_path):
     from rs_embed.api import export_batch
 
     export_batch(
         spatials=[_SPATIAL],
         temporal=_TEMPORAL,
         models=["mock_model"],
-        out=str(tmp_path / "combined_out"),
-        layout="combined",
+        target=ExportTarget.combined(str(tmp_path / "combined_out.npz")),
+        config=ExportConfig(
+            save_inputs=False,
+            save_embeddings=True,
+            save_manifest=False,
+            show_progress=False,
+        ),
         backend="local",
-        save_inputs=False,
-        save_embeddings=True,
-        save_manifest=False,
-        show_progress=False,
     )
     assert (tmp_path / "combined_out.npz").exists()
 
@@ -729,33 +732,6 @@ def test_export_batch_object_style_target_and_config(tmp_path):
         backend="local",
     )
     assert (tmp_path / "sample.npz").exists()
-
-
-def test_export_batch_rejects_mixing_target_and_legacy_output_args(tmp_path):
-    from rs_embed.api import export_batch
-
-    with pytest.raises(ModelError, match="target=ExportTarget"):
-        export_batch(
-            spatials=[_SPATIAL],
-            temporal=_TEMPORAL,
-            models=["mock_model"],
-            target=ExportTarget.combined(str(tmp_path / "combined")),
-            out_path=str(tmp_path / "legacy"),
-        )
-
-
-def test_export_batch_rejects_mixing_config_and_legacy_config_args(tmp_path):
-    from rs_embed.api import export_batch
-
-    with pytest.raises(ModelError, match="config=ExportConfig"):
-        export_batch(
-            spatials=[_SPATIAL],
-            temporal=_TEMPORAL,
-            models=["mock_model"],
-            target=ExportTarget.combined(str(tmp_path / "combined")),
-            config=ExportConfig(show_progress=False),
-            save_inputs=False,
-        )
 
 
 def test_public_list_models_uses_catalog_not_runtime_registry():
@@ -791,10 +767,8 @@ def test_export_batch_infer_batch_size_is_independent_from_chunk_size(monkeypatc
         spatials=[_SPATIAL],
         temporal=_TEMPORAL,
         models=["mock_model"],
-        out_path=str(tmp_path / "combined"),
-        chunk_size=32,
-        infer_batch_size=5,
-        show_progress=False,
+        target=ExportTarget.combined(str(tmp_path / "combined")),
+        config=ExportConfig(chunk_size=32, infer_batch_size=5, show_progress=False),
     )
 
     assert result == {"status": "ok"}
@@ -817,10 +791,10 @@ def test_export_batch_modality_resolves_model_sensor(monkeypatch, tmp_path):
         spatials=[_SPATIAL],
         temporal=_TEMPORAL,
         models=["mock_multi"],
-        out_path=str(tmp_path / "combined"),
+        target=ExportTarget.combined(str(tmp_path / "combined")),
+        config=ExportConfig(show_progress=False),
         modality="s1",
         backend="gee",
-        show_progress=False,
     )
 
     assert result == {"status": "ok"}
@@ -846,10 +820,10 @@ def test_export_batch_fetch_resolves_model_sensor(monkeypatch, tmp_path):
         spatials=[_SPATIAL],
         temporal=_TEMPORAL,
         models=["mock_multi"],
-        out_path=str(tmp_path / "combined"),
+        target=ExportTarget.combined(str(tmp_path / "combined")),
+        config=ExportConfig(show_progress=False),
         fetch=FetchSpec(scale_m=30, cloudy_pct=5),
         backend="gee",
-        show_progress=False,
     )
 
     assert result == {"status": "ok"}
@@ -884,9 +858,9 @@ def test_export_batch_rejects_sensor_and_fetch_conflict(monkeypatch, tmp_path):
                     fetch=FetchSpec(scale_m=20),
                 )
             ],
-            out_path=str(tmp_path / "combined"),
+            target=ExportTarget.combined(str(tmp_path / "combined")),
+            config=ExportConfig(show_progress=False),
             backend="gee",
-            show_progress=False,
         )
 
 
@@ -1121,10 +1095,9 @@ def test_export_batch_assert_supported_rejects_incompatible_backend(tmp_path):
             spatials=[_SPATIAL],
             temporal=_TEMPORAL,
             models=["gee_only_export_mock"],
-            out_dir=str(tmp_path),
+            target=ExportTarget.per_item(str(tmp_path)),
+            config=ExportConfig(save_embeddings=False, show_progress=False),
             backend="local",
-            save_embeddings=False,
-            show_progress=False,
         )
 
     registry._REGISTRY.pop("gee_only_export_mock", None)
@@ -1143,11 +1116,10 @@ def test_export_batch_assert_supported_rejects_incompatible_output_mode(tmp_path
             spatials=[_SPATIAL],
             temporal=_TEMPORAL,
             models=["gee_only_export_mock"],
-            out_dir=str(tmp_path),
+            target=ExportTarget.per_item(str(tmp_path)),
+            config=ExportConfig(save_embeddings=False, show_progress=False),
             backend="gee",
             output=OutputSpec.grid(),
-            save_embeddings=False,
-            show_progress=False,
         )
 
     registry._REGISTRY.pop("gee_only_export_mock", None)
@@ -1162,12 +1134,14 @@ def test_export_batch_assert_supported_passes_for_compatible_model(tmp_path):
         spatials=[_SPATIAL],
         temporal=_TEMPORAL,
         models=["mock_model"],
-        out_dir=str(tmp_path),
+        target=ExportTarget.per_item(str(tmp_path)),
+        config=ExportConfig(
+            save_inputs=False,
+            save_embeddings=True,
+            save_manifest=False,
+            show_progress=False,
+        ),
         backend="local",
-        save_inputs=False,
-        save_embeddings=True,
-        save_manifest=False,
-        show_progress=False,
     )
     assert len(results) == 1
     assert results[0]["status"] == "ok"
@@ -1197,12 +1171,14 @@ def test_export_batch_backend_resolution_before_assert_supported(tmp_path, monke
         spatials=[_SPATIAL],
         temporal=_TEMPORAL,
         models=["mock_precomputed_local"],
-        out_dir=str(tmp_path),
+        target=ExportTarget.per_item(str(tmp_path)),
+        config=ExportConfig(
+            save_inputs=False,
+            save_embeddings=True,
+            save_manifest=False,
+            show_progress=False,
+        ),
         backend="gee",
-        save_inputs=False,
-        save_embeddings=True,
-        save_manifest=False,
-        show_progress=False,
     )
     assert len(results) == 1
     assert results[0]["status"] == "ok"

--- a/tests/test_export_batch.py
+++ b/tests/test_export_batch.py
@@ -6,7 +6,7 @@ import pytest
 from rs_embed.core import registry
 from rs_embed.core.embedding import Embedding
 from rs_embed.core.specs import InputPrepSpec, OutputSpec, PointBuffer, SensorSpec, TemporalSpec
-from rs_embed.core.types import ExportConfig, FetchResult
+from rs_embed.core.types import ExportConfig, ExportTarget, FetchResult
 from rs_embed.embedders.base import EmbedderBase
 from rs_embed.tools.runtime import get_embedder_bundle_cached
 
@@ -146,15 +146,17 @@ def test_export_batch_prefetch_dedup_across_models(tmp_path, monkeypatch):
         spatials=spatials,
         temporal=temporal,
         models=["dummy_a", "dummy_b"],
-        out_dir=str(out_dir),
+        target=ExportTarget.per_item(str(out_dir)),
+        config=ExportConfig(
+            save_inputs=True,
+            save_embeddings=True,
+            chunk_size=10,
+            num_workers=4,
+        ),
         backend="gee",
         device="cpu",
         output=OutputSpec.pooled(),
         sensor=sensor,
-        save_inputs=True,
-        save_embeddings=True,
-        chunk_size=10,
-        num_workers=4,
     )
 
     # One fetch per spatial (dedup across models sharing identical sensor)
@@ -275,13 +277,11 @@ def test_export_batch_prefetch_reuses_superset_and_slices_subset(tmp_path, monke
         spatials=spatials,
         temporal=TemporalSpec.range("2020-01-01", "2020-02-01"),
         models=["dummy_rgb_subset", "dummy_s2_superset"],
-        out_dir=str(out_dir),
+        target=ExportTarget.per_item(str(out_dir)),
+        config=ExportConfig(save_inputs=False, save_embeddings=True, show_progress=False),
         backend="gee",
         device="cpu",
         output=OutputSpec.pooled(),
-        save_inputs=False,
-        save_embeddings=True,
-        show_progress=False,
     )
 
     assert fetch_calls["n"] == len(spatials)
@@ -416,13 +416,11 @@ def test_export_batch_prefetch_merged_groups_skip_custom_fetcher(tmp_path, monke
         spatials=spatials,
         temporal=TemporalSpec.range("2020-01-01", "2020-02-01"),
         models=["dummy_rgb_custom_fetch", "dummy_s2_superset_custom_group"],
-        out_dir=str(out_dir),
+        target=ExportTarget.per_item(str(out_dir)),
+        config=ExportConfig(save_inputs=False, save_embeddings=True, show_progress=False),
         backend="gee",
         device="cpu",
         output=OutputSpec.pooled(),
-        save_inputs=False,
-        save_embeddings=True,
-        show_progress=False,
     )
 
     assert generic_fetch["n"] == len(spatials)
@@ -504,14 +502,12 @@ def test_export_batch_combined_npz_dedup(tmp_path, monkeypatch):
         spatials=spatials,
         temporal=temporal,
         models=["dummy_c"],
-        out_path=str(out_path),
+        target=ExportTarget.combined(str(out_path)),
+        config=ExportConfig(save_inputs=True, save_embeddings=True, num_workers=4),
         backend="gee",
         device="cpu",
         output=OutputSpec.pooled(),
         sensor=sensor,
-        save_inputs=True,
-        save_embeddings=True,
-        num_workers=4,
     )
 
     assert out_path.exists()
@@ -582,13 +578,11 @@ def test_export_batch_combined_prefetch_checkpoint_handles_variable_input_shapes
         spatials=spatials,
         temporal=TemporalSpec.range("2020-01-01", "2020-02-01"),
         models=["dummy_var_shape"],
-        out_path=str(out_path),
+        target=ExportTarget.combined(str(out_path)),
+        config=ExportConfig(save_inputs=True, save_embeddings=True, show_progress=False),
         backend="gee",
         device="cpu",
         output=OutputSpec.pooled(),
-        save_inputs=True,
-        save_embeddings=True,
-        show_progress=False,
     )
 
     assert out_path.exists()
@@ -674,13 +668,11 @@ def test_export_batch_combined_falls_back_to_single_when_batch_api_fails(tmp_pat
         ],
         temporal=TemporalSpec.range("2020-01-01", "2020-02-01"),
         models=["dummy_batch_fail"],
-        out_path=str(out_path),
+        target=ExportTarget.combined(str(out_path)),
+        config=ExportConfig(save_inputs=True, save_embeddings=True, show_progress=False),
         backend="gee",
         device="cpu",
         output=OutputSpec.pooled(),
-        save_inputs=True,
-        save_embeddings=True,
-        show_progress=False,
     )
 
     assert out_path.exists()
@@ -792,13 +784,11 @@ def test_export_batch_combined_prefetch_reuses_superset_and_slices_subset(tmp_pa
         spatials=spatials,
         temporal=TemporalSpec.year(2022),
         models=["dummy_rgb_subset_combined", "dummy_s2_superset_combined"],
-        out_path=str(out_path),
+        target=ExportTarget.combined(str(out_path)),
+        config=ExportConfig(save_inputs=False, save_embeddings=True, show_progress=False),
         backend="gee",
         device="cpu",
         output=OutputSpec.pooled(),
-        save_inputs=False,
-        save_embeddings=True,
-        show_progress=False,
     )
 
     assert out_path.exists()
@@ -860,13 +850,11 @@ def test_export_batch_per_item_prefers_batch_inference_on_gpu(tmp_path, monkeypa
         ],
         temporal=TemporalSpec.year(2022),
         models=["dummy_batch_gpu_dir"],
-        out_dir=str(out_dir),
+        target=ExportTarget.per_item(str(out_dir)),
+        config=ExportConfig(save_inputs=False, save_embeddings=True, show_progress=False),
         backend="gee",
         device="cuda",
         output=OutputSpec.pooled(),
-        save_inputs=False,
-        save_embeddings=True,
-        show_progress=False,
     )
 
     assert (out_dir / "p00000.npz").exists()
@@ -925,13 +913,11 @@ def test_export_batch_per_item_cpu_defaults_to_single_inference(tmp_path, monkey
         ],
         temporal=TemporalSpec.year(2022),
         models=["dummy_batch_gpu_dir_single"],
-        out_dir=str(out_dir),
+        target=ExportTarget.per_item(str(out_dir)),
+        config=ExportConfig(save_inputs=False, save_embeddings=True, show_progress=False),
         backend="gee",
         device="cpu",
         output=OutputSpec.pooled(),
-        save_inputs=False,
-        save_embeddings=True,
-        show_progress=False,
     )
 
     assert DummyBatchGPUOff.batch_calls == 0
@@ -1002,15 +988,17 @@ def test_export_batch_netcdf_per_item(tmp_path, monkeypatch):
         spatials=spatials,
         temporal=temporal,
         models=["dummy_nc"],
-        out_dir=str(out_dir),
+        target=ExportTarget.per_item(str(out_dir)),
+        config=ExportConfig(
+            format="netcdf",
+            save_inputs=True,
+            save_embeddings=True,
+            save_manifest=True,
+        ),
         backend="gee",
         device="cpu",
         output=OutputSpec.pooled(),
         sensor=sensor,
-        format="netcdf",
-        save_inputs=True,
-        save_embeddings=True,
-        save_manifest=True,
     )
 
     assert len(res) == len(spatials)
@@ -1095,14 +1083,12 @@ def test_export_batch_netcdf_combined(tmp_path, monkeypatch):
         spatials=spatials,
         temporal=temporal,
         models=["dummy_comb"],
-        out_path=str(out_path),
+        target=ExportTarget.combined(str(out_path)),
+        config=ExportConfig(format="netcdf", save_inputs=True, save_embeddings=True),
         backend="gee",
         device="cpu",
         output=OutputSpec.pooled(),
         sensor=sensor,
-        format="netcdf",
-        save_inputs=True,
-        save_embeddings=True,
     )
 
     assert out_path.exists()
@@ -1172,13 +1158,11 @@ def test_export_batch_combined_fail_on_bad_input(tmp_path, monkeypatch):
             spatials=[PointBuffer(lon=0, lat=0, buffer_m=10)],
             temporal=TemporalSpec.year(2022),
             models=["dummy_bad"],
-            out_path=str(tmp_path / "bad.npz"),
+            target=ExportTarget.combined(str(tmp_path / "bad.npz")),
+            config=ExportConfig(save_inputs=True, save_embeddings=False, fail_on_bad_input=True),
             backend="gee",
             output=OutputSpec.pooled(),
             sensor=SensorSpec(collection="C", bands=("B1",)),
-            save_inputs=True,
-            save_embeddings=False,
-            fail_on_bad_input=True,
         )
 
 
@@ -1242,14 +1226,16 @@ def test_export_batch_combined_partial_inputs_include_indices(tmp_path, monkeypa
         ],
         temporal=TemporalSpec.year(2022),
         models=["dummy_input_only"],
-        out_path=str(out_path),
+        target=ExportTarget.combined(str(out_path)),
+        config=ExportConfig(
+            save_inputs=True,
+            save_embeddings=False,
+            continue_on_error=True,
+            show_progress=False,
+        ),
         backend="gee",
         output=OutputSpec.pooled(),
         sensor=SensorSpec(collection="C", bands=("B1",)),
-        save_inputs=True,
-        save_embeddings=False,
-        continue_on_error=True,
-        show_progress=False,
     )
 
     assert out_path.exists()
@@ -1327,12 +1313,11 @@ def test_export_batch_prefetch_used_even_without_saving_inputs(tmp_path, monkeyp
         spatials=spatials,
         temporal=TemporalSpec.year(2022),
         models=["dummy_need_input"],
-        out_dir=str(out_dir),
+        target=ExportTarget.per_item(str(out_dir)),
+        config=ExportConfig(save_inputs=False, save_embeddings=True),
         backend="gee",
         output=OutputSpec.pooled(),
         sensor=sensor,
-        save_inputs=False,
-        save_embeddings=True,
     )
 
     assert calls["fetch"] == len(spatials)
@@ -1421,13 +1406,11 @@ def test_export_batch_continue_on_error_partial_manifest(tmp_path, monkeypatch):
         spatials=[PointBuffer(lon=0, lat=0, buffer_m=10)],
         temporal=TemporalSpec.year(2022),
         models=["dummy_good", "dummy_bad2"],
-        out_dir=str(out_dir),
+        target=ExportTarget.per_item(str(out_dir)),
+        config=ExportConfig(save_inputs=True, save_embeddings=True, continue_on_error=True),
         backend="gee",
         output=OutputSpec.pooled(),
         sensor=SensorSpec(collection="C", bands=("B1",)),
-        save_inputs=True,
-        save_embeddings=True,
-        continue_on_error=True,
     )
 
     assert len(res) == 1
@@ -1488,11 +1471,10 @@ def test_export_batch_combined_prefers_model_batch_api(tmp_path):
         ],
         temporal=TemporalSpec.year(2022),
         models=["dummy_batch"],
-        out_path=str(out_path),
+        target=ExportTarget.combined(str(out_path)),
+        config=ExportConfig(save_inputs=False, save_embeddings=True),
         backend="local",
         output=OutputSpec.pooled(),
-        save_inputs=False,
-        save_embeddings=True,
     )
 
     assert out_path.exists()
@@ -1585,11 +1567,7 @@ def test_export_batch_per_item_cpu_honors_config_input_prep_tile(tmp_path, monke
         spatials=[PointBuffer(lon=0.0, lat=0.0, buffer_m=10)],
         temporal=TemporalSpec.range("2020-01-01", "2020-02-01"),
         models=["dummy_tile_per_item"],
-        out_dir=str(out_dir),
-        backend="gee",
-        device="cpu",
-        output=OutputSpec.pooled(),
-        sensor=SensorSpec(collection="C", bands=("B1", "B2", "B3"), scale_m=10),
+        target=ExportTarget.per_item(str(out_dir)),
         config=ExportConfig(
             save_inputs=True,
             save_embeddings=True,
@@ -1597,6 +1575,10 @@ def test_export_batch_per_item_cpu_honors_config_input_prep_tile(tmp_path, monke
             async_write=False,
             input_prep=InputPrepSpec.tile(tile_size=4, max_tiles=9),
         ),
+        backend="gee",
+        device="cpu",
+        output=OutputSpec.pooled(),
+        sensor=SensorSpec(collection="C", bands=("B1", "B2", "B3"), scale_m=10),
     )
 
     assert len(res) == 1
@@ -1691,17 +1673,17 @@ def test_export_batch_combined_honors_config_input_prep_tile(tmp_path, monkeypat
         spatials=[PointBuffer(lon=0.0, lat=0.0, buffer_m=10)],
         temporal=TemporalSpec.range("2020-01-01", "2020-02-01"),
         models=["dummy_tile_combined"],
-        out_path=str(out_path),
-        backend="gee",
-        device="cpu",
-        output=OutputSpec.pooled(),
-        sensor=SensorSpec(collection="C", bands=("B1", "B2", "B3"), scale_m=10),
+        target=ExportTarget.combined(str(out_path)),
         config=ExportConfig(
             save_inputs=True,
             save_embeddings=True,
             show_progress=False,
             input_prep=InputPrepSpec.tile(tile_size=4, max_tiles=9),
         ),
+        backend="gee",
+        device="cpu",
+        output=OutputSpec.pooled(),
+        sensor=SensorSpec(collection="C", bands=("B1", "B2", "B3"), scale_m=10),
     )
 
     assert out_path.exists()
@@ -1794,12 +1776,11 @@ def test_export_batch_dedup_inputs_across_models_in_file(tmp_path, monkeypatch):
         spatials=[PointBuffer(lon=0, lat=0, buffer_m=10)],
         temporal=TemporalSpec.year(2022),
         models=["dummy_dedup_a", "dummy_dedup_b"],
-        out_dir=str(out_dir),
+        target=ExportTarget.per_item(str(out_dir)),
+        config=ExportConfig(save_inputs=True, save_embeddings=True),
         backend="gee",
         output=OutputSpec.pooled(),
         sensor=SensorSpec(collection="C", bands=("B1",)),
-        save_inputs=True,
-        save_embeddings=True,
     )
 
     npz = np.load(out_dir / "p00000.npz")
@@ -1849,12 +1830,10 @@ def test_export_batch_resume_out_dir_skips_existing(tmp_path):
         spatials=spatials,
         temporal=TemporalSpec.year(2022),
         models=["dummy_resume_dir"],
-        out_dir=str(out_dir),
+        target=ExportTarget.per_item(str(out_dir)),
+        config=ExportConfig(save_inputs=False, save_embeddings=True, show_progress=False),
         backend="local",
         output=OutputSpec.pooled(),
-        save_inputs=False,
-        save_embeddings=True,
-        show_progress=False,
     )
     assert len(first) == len(spatials)
     assert DummyResumeDir.calls == len(spatials)
@@ -1863,13 +1842,12 @@ def test_export_batch_resume_out_dir_skips_existing(tmp_path):
         spatials=spatials,
         temporal=TemporalSpec.year(2022),
         models=["dummy_resume_dir"],
-        out_dir=str(out_dir),
+        target=ExportTarget.per_item(str(out_dir)),
+        config=ExportConfig(
+            save_inputs=False, save_embeddings=True, resume=True, show_progress=False
+        ),
         backend="local",
         output=OutputSpec.pooled(),
-        save_inputs=False,
-        save_embeddings=True,
-        resume=True,
-        show_progress=False,
     )
     assert len(second) == len(spatials)
     assert DummyResumeDir.calls == len(spatials)
@@ -1913,12 +1891,10 @@ def test_export_batch_resume_out_path_skips_existing(tmp_path):
         spatials=spatials,
         temporal=TemporalSpec.year(2022),
         models=["dummy_resume_combined"],
-        out_path=str(out_path),
+        target=ExportTarget.combined(str(out_path)),
+        config=ExportConfig(save_inputs=False, save_embeddings=True, show_progress=False),
         backend="local",
         output=OutputSpec.pooled(),
-        save_inputs=False,
-        save_embeddings=True,
-        show_progress=False,
     )
     assert DummyResumeCombined.calls == len(spatials)
 
@@ -1926,13 +1902,12 @@ def test_export_batch_resume_out_path_skips_existing(tmp_path):
         spatials=spatials,
         temporal=TemporalSpec.year(2022),
         models=["dummy_resume_combined"],
-        out_path=str(out_path),
+        target=ExportTarget.combined(str(out_path)),
+        config=ExportConfig(
+            save_inputs=False, save_embeddings=True, resume=True, show_progress=False
+        ),
         backend="local",
         output=OutputSpec.pooled(),
-        save_inputs=False,
-        save_embeddings=True,
-        resume=True,
-        show_progress=False,
     )
     assert bool(skipped.get("resume_skipped"))
     assert DummyResumeCombined.calls == len(spatials)
@@ -1997,13 +1972,11 @@ def test_export_batch_combined_saves_prefetch_checkpoint_before_inference(tmp_pa
             ],
             temporal=TemporalSpec.year(2022),
             models=["dummy_crash_after_fetch"],
-            out_path=str(out_path),
+            target=ExportTarget.combined(str(out_path)),
+            config=ExportConfig(save_inputs=False, save_embeddings=True, show_progress=False),
             backend="gee",
             output=OutputSpec.pooled(),
             sensor=SensorSpec(collection="C", bands=("B1", "B2")),
-            save_inputs=False,
-            save_embeddings=True,
-            show_progress=False,
         )
 
     assert out_path.exists()
@@ -2119,13 +2092,11 @@ def test_export_batch_combined_resume_continues_remaining_models(tmp_path, monke
             spatials=spatials,
             temporal=TemporalSpec.year(2022),
             models=["dummy_resume_good_ckpt", "dummy_resume_flaky_ckpt"],
-            out_path=str(out_path),
+            target=ExportTarget.combined(str(out_path)),
+            config=ExportConfig(save_inputs=False, save_embeddings=True, show_progress=False),
             backend="gee",
             output=OutputSpec.pooled(),
             sensor=SensorSpec(collection="C", bands=("B1", "B2")),
-            save_inputs=False,
-            save_embeddings=True,
-            show_progress=False,
         )
 
     first_good_calls = DummyResumeGood.calls
@@ -2138,14 +2109,13 @@ def test_export_batch_combined_resume_continues_remaining_models(tmp_path, monke
         spatials=spatials,
         temporal=TemporalSpec.year(2022),
         models=["dummy_resume_good_ckpt", "dummy_resume_flaky_ckpt"],
-        out_path=str(out_path),
+        target=ExportTarget.combined(str(out_path)),
+        config=ExportConfig(
+            save_inputs=False, save_embeddings=True, resume=True, show_progress=False
+        ),
         backend="gee",
         output=OutputSpec.pooled(),
         sensor=SensorSpec(collection="C", bands=("B1", "B2")),
-        save_inputs=False,
-        save_embeddings=True,
-        resume=True,
-        show_progress=False,
     )
 
     assert result["status"] == "ok"
@@ -2222,13 +2192,12 @@ def test_export_batch_progress_updates_point_and_model_bars(tmp_path, monkeypatc
         spatials=spatials,
         temporal=TemporalSpec.year(2022),
         models=["dummy_progress"],
-        out_dir=str(tmp_path / "progress"),
+        target=ExportTarget.per_item(str(tmp_path / "progress")),
+        config=ExportConfig(
+            save_inputs=False, save_embeddings=True, chunk_size=1, show_progress=True
+        ),
         backend="local",
         output=OutputSpec.pooled(),
-        save_inputs=False,
-        save_embeddings=True,
-        chunk_size=1,
-        show_progress=True,
     )
 
     assert state["export_batch"]["total"] == len(spatials)
@@ -2320,13 +2289,12 @@ def test_export_batch_combined_progress_updates_model_inference(tmp_path, monkey
         spatials=spatials,
         temporal=TemporalSpec.year(2022),
         models=["dummy_batch_progress", "dummy_single_progress"],
-        out_path=str(tmp_path / "combined_progress.npz"),
+        target=ExportTarget.combined(str(tmp_path / "combined_progress.npz")),
+        config=ExportConfig(
+            save_inputs=False, save_embeddings=True, chunk_size=1, show_progress=True
+        ),
         backend="local",
         output=OutputSpec.pooled(),
-        save_inputs=False,
-        save_embeddings=True,
-        chunk_size=1,
-        show_progress=True,
     )
 
     assert state["export_batch[combined]"]["total"] == 2
@@ -2387,13 +2355,12 @@ def test_export_batch_combined_progress_fills_on_model_init_failure(tmp_path, mo
         spatials=spatials,
         temporal=TemporalSpec.year(2022),
         models=["dummy_init_fail"],
-        out_path=str(tmp_path / "combined_progress_init_fail.npz"),
+        target=ExportTarget.combined(str(tmp_path / "combined_progress_init_fail.npz")),
+        config=ExportConfig(
+            save_inputs=False, save_embeddings=True, continue_on_error=True, show_progress=True
+        ),
         backend="local",
         output=OutputSpec.pooled(),
-        save_inputs=False,
-        save_embeddings=True,
-        continue_on_error=True,
-        show_progress=True,
     )
 
     assert result["status"] == "failed"
@@ -2429,12 +2396,10 @@ def test_export_batch_combined_embedder_without_input_chw_kwarg(tmp_path):
         spatials=spatials,
         temporal=TemporalSpec.year(2022),
         models=["dummy_no_input_kwarg"],
-        out_path=str(out_path),
+        target=ExportTarget.combined(str(out_path)),
+        config=ExportConfig(save_inputs=False, save_embeddings=True, show_progress=False),
         backend="local",
         output=OutputSpec.pooled(),
-        save_inputs=False,
-        save_embeddings=True,
-        show_progress=False,
     )
 
     assert out_path.exists()

--- a/tests/test_export_batch_terrafm_s1_fetch.py
+++ b/tests/test_export_batch_terrafm_s1_fetch.py
@@ -5,7 +5,7 @@ import numpy as np
 from rs_embed.core import registry
 from rs_embed.core.embedding import Embedding
 from rs_embed.core.specs import OutputSpec, PointBuffer, SensorSpec, TemporalSpec
-from rs_embed.core.types import FetchResult
+from rs_embed.core.types import ExportConfig, ExportTarget, FetchResult
 from rs_embed.embedders.base import EmbedderBase
 from rs_embed.pipelines.point_payload import build_one_point_payload
 from rs_embed.tools.export_requests import ExportModelRequest
@@ -115,13 +115,11 @@ def test_export_batch_prefetch_preserves_terrafm_s1_sensor_fields(tmp_path, monk
         spatials=[PointBuffer(lon=0.0, lat=0.0, buffer_m=10)],
         temporal=TemporalSpec.range("2020-01-01", "2020-02-01"),
         models=[ExportModelRequest(name="dummy_terrafm_s1", sensor=sensor)],
-        out_dir=str(out_dir),
+        target=ExportTarget.per_item(str(out_dir)),
+        config=ExportConfig(save_inputs=True, save_embeddings=True, show_progress=False),
         backend="gee",
         device="cpu",
         output=OutputSpec.pooled(),
-        save_inputs=True,
-        save_embeddings=True,
-        show_progress=False,
     )
 
     manifest = manifests[0] if isinstance(manifests, list) else manifests

--- a/tests/test_export_wrapper.py
+++ b/tests/test_export_wrapper.py
@@ -1,4 +1,5 @@
 from rs_embed.core.specs import FetchSpec, PointBuffer
+from rs_embed.core.types import ExportConfig, ExportTarget
 from rs_embed.export import export_npz
 
 
@@ -16,15 +17,14 @@ def test_export_npz_delegates(monkeypatch, tmp_path):
         temporal=None,
         models=["mock_model"],
         out_path=str(tmp_path / "one"),
-        save_inputs=False,
-        save_embeddings=False,
-        save_manifest=False,
+        config=ExportConfig(save_inputs=False, save_embeddings=False, save_manifest=False),
     )
 
     assert out == {"ok": True}
-    assert captured["format"] == "npz"
+    assert captured["config"].format == "npz"
     assert captured["spatials"]
-    assert captured["out_path"].endswith(".npz")
+    assert isinstance(captured["target"], ExportTarget)
+    assert captured["target"].out_file.endswith(".npz")
 
 
 def test_export_npz_delegates_fetch(monkeypatch, tmp_path):
@@ -46,3 +46,25 @@ def test_export_npz_delegates_fetch(monkeypatch, tmp_path):
 
     assert out == {"ok": True}
     assert captured["fetch"] == FetchSpec(scale_m=20)
+    assert captured["config"].format == "npz"
+
+
+def test_export_npz_forces_npz_format_even_when_config_specifies_other(monkeypatch, tmp_path):
+    """export_npz always forces format='npz', overriding any config.format value."""
+    captured = {}
+
+    def _fake_export_batch(**kwargs):
+        captured.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr("rs_embed.api.export_batch", _fake_export_batch)
+
+    export_npz(
+        spatial=PointBuffer(lon=0.0, lat=0.0, buffer_m=10),
+        temporal=None,
+        models=["mock_model"],
+        out_path=str(tmp_path / "one"),
+        config=ExportConfig(format="netcdf"),
+    )
+
+    assert captured["config"].format == "npz"


### PR DESCRIPTION
## Summary

The `export_batch()` signature had 29 parameters — 20 of which were flat duplicates of `ExportConfig` and `ExportTarget` fields, already labelled *"Legacy config-style keyword arguments; new code should prefer `config=ExportConfig(...)`"* in the docstring. This PR removes that legacy path entirely, since there is no released version to be backward-compatible with.

**Before:**
```python
export_batch(
    spatials=..., temporal=..., models=...,
    out_dir="/tmp/out",          # flat target kwargs
    format="netcdf",             # flat config kwargs
    save_inputs=True,
    num_workers=8,
    show_progress=False,
    ...
)
```

**After:**
```python
export_batch(
    spatials=..., temporal=..., models=...,
    target=ExportTarget.per_item("/tmp/out"),
    config=ExportConfig(format="netcdf", save_inputs=True, num_workers=8, show_progress=False),
)
```

## Changes

- **`export_batch()`** — removed 15 flat config kwargs and 5 flat target kwargs; `target: ExportTarget` is now required, `config: ExportConfig = ExportConfig()` is optional with defaults
- **`export_npz()`** — replaced 9 flat config kwargs with `config: ExportConfig`; format is always forced to `"npz"` regardless of `config.format`
- **`export_requests.py`** — deleted `normalize_export_config()`, `_resolve_export_batch_target()`, and `normalize_export_layout()` (all dead code after this change); simplified `normalize_export_target()` to accept only `ExportTarget`
- **Tests** — updated all 25+ `export_batch` call sites; removed 8 tests for legacy-only paths; added tests covering `normalize_export_target` validation errors and `export_npz` format-override behaviour

Net: -248 lines. 478 tests pass.

## Notes

This is directly related to the `export_batch` API review mentioned in #44. Happy to adjust if the maintainers have a different direction in mind for the final API shape.