### PR TITLE
License fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "rs-embed"
 dynamic = ["version"]
 description = "Unified ROI->embedding interface for remote sensing foundation models."
 readme = "README.md"
-license = "Apache-2.0"
+license = "Apache-2.0 AND MIT"
 requires-python = ">=3.12"
 authors = [
   { name = "Dingqi Ye" },


### PR DESCRIPTION
## Summary

rs-embed contains a lot of vendored libraries under both Apache-2.0 and MIT licenses. Thus, the license of the entire library should be "Apache-2.0 AND MIT".

## Related Issue

N/A

## Testing

- [ ] I ran the relevant tests locally.
- [ ] I updated docs for user-facing behavior changes.
- [ ] I updated `CHANGELOG.md` for user-facing API, model, semantic, or installation changes.
- [x] This PR does not need a changelog entry.

## Notes

You probably also need to add a copyright header to all vendored files. I don't think I saw any files copied from TorchGeo (technically you don't even need `LICENSE.torchgeo`) but this would look like:
```python
# Copyright (c) TorchGeo Contributors. All rights reserved.
# Licensed under the MIT License.
```
if there were any files from TorchGeo.