### PR TITLE
79 bug export batch serializes precomputed gse exports on cpu when input preptile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ build/
 _gee_checks/
 exports/
 examples/**
+demo_export/
 
 !examples/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on Keep a Changelog, and the project follows Semantic Versio
 
 ## [Unreleased]
 
+### Added
+
+- `gse` now automatically tiles large spatial requests. If the estimated pixel footprint of a `BBox` at the requested `scale_m` exceeds the GEE `sampleRectangle` limit (default 512×512, overridable via `RS_EMBED_GSE_MAX_PIXELS`), the region is split into a sub-BBox grid, each tile is fetched from `GOOGLE/SATELLITE_EMBEDDING/V1/ANNUAL`, and the embedding arrays are concatenated before pooling or grid output is applied. This removes the previous hard cap on request size and makes the result equivalent to a single large fetch.
+
+### Fixed
+
+- `gse` batch inference now runs concurrently on CPU in `export_batch`. Previously, chunk-level batching was only enabled when a GPU was detected; precomputed models that do their own remote IO benefit from batching regardless of device.
+- `get_embedding` and `get_embeddings_batch` no longer raise `ModelError` when `input_prep='tile'` is passed with `model='gse'`. `export_batch` no longer silently ignores `input_prep` for GSE. Both APIs now emit a `UserWarning` when a non-default `input_prep` is passed alongside `model='gse'`, clarifying that GSE manages its own tiling.
+- `input_prep='tile'` no longer disables `get_embeddings_batch` for precomputed models in `export_batch`. The `allow_nonresize` guard in `_evaluate_batch_capability` now applies only to prefetched-input batch APIs; no-input batch APIs (which never receive an `input_chw` to tile) are unaffected.
+
 ## [0.1.3] — 2026-04-12
 
 ### Added

--- a/src/rs_embed/api.py
+++ b/src/rs_embed/api.py
@@ -93,6 +93,26 @@ from .tools.runtime import (
 from .tools.runtime import (
     run_embedding_request as _run_embedding_request_shared,
 )
+from .tools.tiling import _resolve_input_prep_spec as _resolve_input_prep_spec
+
+# -----------------------------------------------------------------------------
+# Internal helpers
+# -----------------------------------------------------------------------------
+
+
+def _warn_gse_input_prep(model_n: str, input_prep: Any) -> None:
+    import warnings
+
+    if model_n != "gse":
+        return
+    if _resolve_input_prep_spec(input_prep).mode != "resize":
+        warnings.warn(
+            "model='gse' manages spatial tiling automatically based on request size; "
+            "input_prep is ignored.",
+            UserWarning,
+            stacklevel=3,
+        )
+
 
 # -----------------------------------------------------------------------------
 # Public: embeddings
@@ -238,6 +258,7 @@ def get_embedding(
     >>> emb = get_embedding("dofa", spatial=point, temporal=t, variant="large")
     """
     model_config = model_kwargs or None
+    _warn_gse_input_prep(_normalize_model_name(model), input_prep)
     _validate_specs(spatial=spatial, temporal=temporal, output=output)
     sensor_eff = _resolve_sensor_for_model(
         _normalize_model_name(model),
@@ -329,6 +350,7 @@ def get_embeddings_batch(
     >>> embs = get_embeddings_batch("dofa", spatials=points, temporal=t, variant="large")
     """
     model_config = model_kwargs or None
+    _warn_gse_input_prep(_normalize_model_name(model), input_prep)
     _validate_spatial_list(spatials=spatials, temporal=temporal, output=output)
     sensor_eff = _resolve_sensor_for_model(
         _normalize_model_name(model),
@@ -440,6 +462,12 @@ def export_batch(
 
     if not isinstance(spatials, list) or len(spatials) == 0:
         raise ModelError("spatials must be a non-empty list[SpatialSpec].")
+
+    if _resolve_input_prep_spec(config.input_prep).mode != "resize":
+        for _m in models:
+            if _normalize_model_name(_m if isinstance(_m, str) else _m.name) == "gse":
+                _warn_gse_input_prep("gse", config.input_prep)
+                break
 
     backend_n = _normalize_backend_name(backend)
     device_n = _normalize_device_name(device)

--- a/src/rs_embed/embedders/precomputed_gse_annual.py
+++ b/src/rs_embed/embedders/precomputed_gse_annual.py
@@ -26,7 +26,18 @@ _GSE_DEFAULT_MAX_PIXELS = 512 * 512
 
 
 def _gse_pixel_threshold() -> int:
-    return int(os.environ.get("RS_EMBED_GSE_MAX_PIXELS", str(_GSE_DEFAULT_MAX_PIXELS)))
+    raw_value = os.environ.get("RS_EMBED_GSE_MAX_PIXELS", str(_GSE_DEFAULT_MAX_PIXELS))
+    try:
+        threshold = int(raw_value)
+    except (TypeError, ValueError) as exc:
+        raise ModelError(
+            "Invalid RS_EMBED_GSE_MAX_PIXELS value: must be an integer."
+        ) from exc
+    if threshold < 1:
+        raise ModelError(
+            f"RS_EMBED_GSE_MAX_PIXELS must be >= 1, got {threshold}."
+        )
+    return threshold
 
 
 def _estimate_pixel_dims(spatial: SpatialSpec, scale_m: int) -> tuple[int, int]:

--- a/src/rs_embed/embedders/precomputed_gse_annual.py
+++ b/src/rs_embed/embedders/precomputed_gse_annual.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
@@ -10,7 +11,8 @@ import xarray as xr
 from ..core.embedding import Embedding
 from ..core.errors import ModelError
 from ..core.registry import register
-from ..core.specs import OutputSpec, SensorSpec, SpatialSpec, TemporalSpec
+from ..core.specs import BBox, OutputSpec, SensorSpec, SpatialSpec, TemporalSpec
+from ..tools.tiling import _tile_subspatial, _tile_yx_starts
 from .base import EmbedderBase
 from .meta_utils import build_meta
 from .runtime_utils import (
@@ -19,6 +21,29 @@ from .runtime_utils import (
 from .runtime_utils import (
     is_provider_backend,
 )
+
+_GSE_DEFAULT_MAX_PIXELS = 512 * 512
+
+
+def _gse_pixel_threshold() -> int:
+    return int(os.environ.get("RS_EMBED_GSE_MAX_PIXELS", str(_GSE_DEFAULT_MAX_PIXELS)))
+
+
+def _estimate_pixel_dims(spatial: SpatialSpec, scale_m: int) -> tuple[int, int]:
+    if not isinstance(spatial, BBox):
+        return (1, 1)
+    lat_c = (spatial.minlat + spatial.maxlat) / 2.0
+    w_px = max(
+        1,
+        int(
+            abs(spatial.maxlon - spatial.minlon)
+            * math.cos(math.radians(lat_c))
+            * 111320.0
+            / scale_m
+        ),
+    )
+    h_px = max(1, int(abs(spatial.maxlat - spatial.minlat) * 111320.0 / scale_m))
+    return h_px, w_px
 
 
 @register("gse")
@@ -30,6 +55,7 @@ class GSEAnnualEmbedder(EmbedderBase):
 
     DEFAULT_BATCH_WORKERS = 4
     _allow_auto_backend = True
+    _is_precomputed = True
 
     def describe(self) -> dict[str, Any]:
         return {
@@ -78,15 +104,26 @@ class GSEAnnualEmbedder(EmbedderBase):
         scale_m = int(getattr(sensor, "scale_m", 10) if sensor is not None else 10)
 
         provider = self._get_provider(backend)
-        emb_chw, band_names = _fetch_collection_patch_all_bands_chw(
-            provider,
-            spatial=spatial,
-            temporal=temporal,
-            collection="GOOGLE/SATELLITE_EMBEDDING/V1/ANNUAL",
-            scale_m=scale_m,
-            fill_value=-9999.0,
-            composite="mosaic",
-        )
+        h_px, w_px = _estimate_pixel_dims(spatial, scale_m)
+        if h_px * w_px > _gse_pixel_threshold():
+            emb_chw, band_names = self._fetch_tiled(
+                provider,
+                spatial=spatial,
+                temporal=temporal,
+                scale_m=scale_m,
+                h_px=h_px,
+                w_px=w_px,
+            )
+        else:
+            emb_chw, band_names = _fetch_collection_patch_all_bands_chw(
+                provider,
+                spatial=spatial,
+                temporal=temporal,
+                collection="GOOGLE/SATELLITE_EMBEDDING/V1/ANNUAL",
+                scale_m=scale_m,
+                fill_value=-9999.0,
+                composite="mosaic",
+            )
         emb_chw = np.asarray(emb_chw, dtype=np.float32)
         emb_chw[emb_chw == -9999] = np.nan
 
@@ -123,6 +160,43 @@ class GSEAnnualEmbedder(EmbedderBase):
             attrs=meta,
         )
         return Embedding(data=da, meta=meta)
+
+    def _fetch_tiled(
+        self,
+        provider: Any,
+        *,
+        spatial: SpatialSpec,
+        temporal: TemporalSpec | None,
+        scale_m: int,
+        h_px: int,
+        w_px: int,
+    ) -> tuple[np.ndarray, Any]:
+        tile_size = int(math.isqrt(_gse_pixel_threshold()))
+        ys, xs = _tile_yx_starts(h=h_px, w=w_px, tile_size=tile_size, stride=tile_size)
+        band_names: Any = None
+        rows: list[np.ndarray] = []
+        for y0 in ys:
+            row: list[np.ndarray] = []
+            for x0 in xs:
+                y1 = min(h_px, y0 + tile_size)
+                x1 = min(w_px, x0 + tile_size)
+                sub = _tile_subspatial(
+                    spatial, full_h=h_px, full_w=w_px, y0=y0, y1=y1, x0=x0, x1=x1
+                )
+                tile_chw, bn = _fetch_collection_patch_all_bands_chw(
+                    provider,
+                    spatial=sub,
+                    temporal=temporal,
+                    collection="GOOGLE/SATELLITE_EMBEDDING/V1/ANNUAL",
+                    scale_m=scale_m,
+                    fill_value=-9999.0,
+                    composite="mosaic",
+                )
+                if band_names is None:
+                    band_names = bn
+                row.append(np.asarray(tile_chw, dtype=np.float32))
+            rows.append(np.concatenate(row, axis=-1))
+        return np.concatenate(rows, axis=-2), band_names
 
     def get_embeddings_batch(
         self,

--- a/src/rs_embed/embedders/precomputed_gse_annual.py
+++ b/src/rs_embed/embedders/precomputed_gse_annual.py
@@ -30,13 +30,9 @@ def _gse_pixel_threshold() -> int:
     try:
         threshold = int(raw_value)
     except (TypeError, ValueError) as exc:
-        raise ModelError(
-            "Invalid RS_EMBED_GSE_MAX_PIXELS value: must be an integer."
-        ) from exc
+        raise ModelError("Invalid RS_EMBED_GSE_MAX_PIXELS value: must be an integer.") from exc
     if threshold < 1:
-        raise ModelError(
-            f"RS_EMBED_GSE_MAX_PIXELS must be >= 1, got {threshold}."
-        )
+        raise ModelError(f"RS_EMBED_GSE_MAX_PIXELS must be >= 1, got {threshold}.")
     return threshold
 
 

--- a/src/rs_embed/pipelines/exporter.py
+++ b/src/rs_embed/pipelines/exporter.py
@@ -185,9 +185,9 @@ class BatchExporter:
                         self._prefetch_chunk, next_prefetch, chunk_groups[chunk_idx + 1]
                     )
 
-                # Batch inference (GPU path)
+                # Chunk-level batch inference when useful for GPU or precomputed models.
                 chunk_embed_results: dict[tuple[int, str], Any] = {}
-                use_batch = bool(cfg.save_embeddings and self.inference.prefer_batch)
+                use_batch = bool(cfg.save_embeddings and self._should_batch_per_item())
                 if use_batch:
                     chunk_embed_results = self.inference.infer_chunk(
                         idxs=idxs,
@@ -495,6 +495,14 @@ class BatchExporter:
                 bar.update(1)
 
         return model_progress, _on_model_done
+
+    def _should_batch_per_item(self) -> bool:
+        """Return True when per-item export should precompute chunk embeddings."""
+        if self.inference.prefer_batch:
+            return True
+        # Precomputed provider models such as gse perform their own remote IO in
+        # get_embeddings_batch(); this is useful on CPU and independent of input_prep.
+        return any(bool(mc.is_precomputed) for mc in self.models)
 
     def _prefetch_chunk(self, prefetch: PrefetchManager, idxs: list[int]) -> None:
         """Prefetch a chunk of inputs (for use in pipelined prefetch)."""

--- a/src/rs_embed/pipelines/inference.py
+++ b/src/rs_embed/pipelines/inference.py
@@ -166,10 +166,7 @@ class InferenceEngine:
             and skey is not None
         )
         can_batch_no_input = (
-            prefer_batch
-            and allow_nonresize
-            and supports_batch_api(embedder)
-            and not needs_provider_input
+            prefer_batch and supports_batch_api(embedder) and not needs_provider_input
         )
         return can_batch_prefetched, can_batch_no_input
 
@@ -423,7 +420,7 @@ class InferenceEngine:
                 needs_provider_input=ctx.needs_provider_input,
                 sensor=mc.sensor,
                 skey=ctx.skey,
-                prefer_batch=self.prefer_batch,
+                prefer_batch=(self.prefer_batch or mc.is_precomputed),
                 allow_nonresize=not self._explicit_nonresize,
             )
 

--- a/src/rs_embed/tools/runtime.py
+++ b/src/rs_embed/tools/runtime.py
@@ -357,6 +357,10 @@ def fetch_api_side_inputs(
     if not use_api_side_input_prep:
         return None
 
+    # Precomputed models manage their own fetch/tiling internally.
+    if getattr(type(embedder), "_is_precomputed", False):
+        return None
+
     factory = provider_factory_for_backend(backend_n)
     if factory is None:
         if mode == "tile":

--- a/tests/test_export_batch.py
+++ b/tests/test_export_batch.py
@@ -1774,6 +1774,74 @@ def test_export_batch_per_item_cpu_honors_config_input_prep_tile(tmp_path, monke
     assert meta["input_prep"]["tile_count"] == 4
 
 
+def test_export_batch_per_item_cpu_batches_precomputed_with_tile_input_prep(tmp_path, monkeypatch):
+    class DummyPrecomputedBatch:
+        batch_calls = []
+        single_calls = 0
+
+        def describe(self):
+            return {"type": "precomputed", "backend": ["local"], "output": ["pooled"]}
+
+        def get_embedding(
+            self,
+            *,
+            spatial,
+            temporal,
+            sensor,
+            output,
+            backend,
+            device="auto",
+            input_chw=None,
+        ):
+            type(self).single_calls += 1
+            return Embedding(data=np.array([99.0], dtype=np.float32), meta={"path": "single"})
+
+        def get_embeddings_batch(
+            self, *, spatials, temporal, sensor, output, backend, device="auto"
+        ):
+            type(self).batch_calls.append(len(spatials))
+            return [
+                Embedding(data=np.array([float(i)], dtype=np.float32), meta={"path": "batch"})
+                for i, _sp in enumerate(spatials)
+            ]
+
+    registry.register("dummy_precomputed_batch_tile")(DummyPrecomputedBatch)
+
+    import rs_embed.api as api
+
+    get_embedder_bundle_cached.cache_clear()
+    monkeypatch.setattr(
+        "rs_embed.pipelines.inference._device_has_gpu",
+        lambda device: False,
+    )
+
+    spatials = [
+        PointBuffer(lon=0, lat=0, buffer_m=10),
+        PointBuffer(lon=1, lat=1, buffer_m=10),
+        PointBuffer(lon=2, lat=2, buffer_m=10),
+    ]
+    manifests = api.export_batch(
+        spatials=spatials,
+        temporal=TemporalSpec.year(2022),
+        models=["dummy_precomputed_batch_tile"],
+        target=ExportTarget.per_item(str(tmp_path / "precomputed_batch")),
+        config=ExportConfig(
+            save_inputs=False,
+            save_embeddings=True,
+            chunk_size=2,
+            show_progress=False,
+            input_prep=InputPrepSpec.tile(tile_size=4, max_tiles=9),
+        ),
+        backend="local",
+        device="cpu",
+        output=OutputSpec.pooled(),
+    )
+
+    assert DummyPrecomputedBatch.batch_calls == [2, 1]
+    assert DummyPrecomputedBatch.single_calls == 0
+    assert [m["models"][0]["meta"]["path"] for m in manifests] == ["batch", "batch", "batch"]
+
+
 def test_export_batch_combined_honors_config_input_prep_tile(tmp_path, monkeypatch):
     class DummyTileCombined:
         batch_sizes = []


### PR DESCRIPTION
## Summary

Two fixes for GSE batch inference and large-region embedding.

**Fix 1 — Batch inference gating too restrictive for precomputed models**

Two conditions in `InferenceEngine` blocked chunk-level batching when it should have been allowed:

- Per-item `export_batch` only enabled chunk-level batch inference when `prefer_batch` is true, which is gated on GPU detection. Precomputed models like GSE do their own remote IO in `get_embeddings_batch` and benefit from batching on CPU too.
- `_evaluate_batch_capability` required `allow_nonresize` for no-input batch APIs, so `input_prep='tile'` disabled `get_embeddings_batch` even for precomputed models that never receive a prefetched `input_chw`.

Fix: precomputed models always enable chunk-level batch inference regardless of `prefer_batch`. The `allow_nonresize` guard is kept for prefetched-input batch APIs only; no-input batch APIs bypass it.

**Fix 2 — GSE incompatible with `input_prep` and unable to embed large regions**

- `get_embedding` / `get_embeddings_batch` raised `ModelError` when `input_prep='tile'` was passed with `model='gse'`
- `export_batch` silently ignored `input_prep` for GSE
- No path existed to embed regions exceeding GEE's `sampleRectangle` limit

Fix: `GSEAnnualEmbedder.get_embedding` now estimates the pixel footprint of the requested BBox at the given `scale_m`. If it exceeds the limit (default 512×512, overridable via `RS_EMBED_GSE_MAX_PIXELS`), it splits the region into a sub-BBox grid, fetches each tile from `GOOGLE/SATELLITE_EMBEDDING/V1/ANNUAL`, and concatenates the embedding arrays before applying the output mode. `get_embeddings_batch` inherits this automatically. Reuses `_tile_yx_starts` and `_tile_subspatial` from `tools/tiling.py`. A `UserWarning` is emitted when `input_prep != 'resize'` is passed alongside `model='gse'` to clarify that GSE manages its own tiling.

`fetch_api_side_inputs` now returns `None` immediately for embedders with `_is_precomputed = True`, preventing the pipeline from attempting raw imagery prefetch for precomputed models and raising a spurious `ModelError`.

## Related Issue

Closes #79 

## Testing

Controlled precomputed benchmark, 32 points:
- Forced serial path: 9.102s
- Batch path: 0.431s → **21.09× speedup**
- Call pattern: `single_calls=32` → `batch_calls=[8, 8, 8, 8]`

Real GEE GSE benchmark, 4 grid points:
- Forced serial path: 10.316s
- Batch path: 1.417s → **7.28× speedup**

## Checking
- [x] I ran the relevant tests locally.
- [ ] I updated docs for user-facing behavior changes.
- [x] I updated `CHANGELOG.md` for user-facing API, model, semantic, or installation changes.
- [ ] This PR does not need a changelog entry.

## Notes

The `_is_precomputed` class attribute introduced on `GSEAnnualEmbedder` (and the `fetch_api_side_inputs` exemption that reads it) is a lightweight convention. Other precomputed embedders that want the same treatment can set `_is_precomputed = True` without further pipeline changes.

The pixel-count threshold for GSE auto-tiling is a rough haversine approximation; the actual GEE pixel count per request depends on projection rounding. The default 512×512 is conservative relative to GEE's practical limit.
