### PR TITLE
fix: CLI broken imports and GEE tile orientation contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ The format is based on Keep a Changelog, and the project follows Semantic Versio
 
 ## [Unreleased]
 
+### Fixed
+
+- **CLI `ModuleNotFoundError` on import.** `rs_embed.cli` was importing from `rs_embed.export` and `rs_embed.inspect`, two modules that do not exist in the current package layout. The imports now point directly to `rs_embed.api` (`export_batch`, `inspect_gee_patch`). The `export-npz` subcommand call site has been updated to match `export_batch`'s current signature: a single spatial argument is wrapped in `spatials=[...]`, the output path becomes `ExportTarget.combined(args.out)`, and the flat boolean flags (`save_inputs`, `save_manifest`, etc.) are grouped into an `ExportConfig` object. The stub injection in `tests/test_cli_parsers.py` that was masking the broken imports has been removed and the integration test updated to patch `cli.export_batch` instead of `cli.export_npz`.
+
+- **GEE tile orientation made explicit and self-contained.** `GEEProvider.fetch_array_chw` now applies `_flip_sample_tile_y` internally before returning, giving the method a documented north-up contract. Previously the flip was the caller's responsibility inside `_fetch_provider_array_chw_with_bbox_fallback`, which created a leaky abstraction: any `ProviderBase` subclass overriding `fetch_array_chw` had to know to return south-up raw data or risk being flipped twice. The caller no longer applies a second flip. The `_sample_image_bands_raw_chw` docstring now documents that GEE's `reproject(crs=..., scale=...)` **without** `.clip()` naturally returns north-up rows, and warns explicitly that adding `.clip()` would change the row ordering to south-up and break the multiframe fetch path. `_flip_sample_tile_y` docstring updated to describe exactly which call pattern requires it and which does not.
+
+### Changed
+
+- **`ProviderBase.fetch_array_chw` contract tightened to north-up.** The method is now required to return north-up CHW float32. Custom provider implementations must either return north-up data directly or apply `_flip_sample_tile_y` internally. Test fake providers in `test_api_helpers.py` have been updated accordingly (north-up row generation, renamed test functions).
+
+### Added
+
+- **Orientation regression test for `_fetch_all_bands_impl`.** `test_gee_provider.py` now includes `test_fetch_all_bands_impl_passes_through_gee_row_order`, which injects a mock GEE `sampleRectangle` response with a known row order and asserts the function output matches exactly (no flip applied). This locks in the pass-through behaviour so that any accidental flip addition is caught immediately, and documents that the north-up guarantee for `fetch_collection_patch_all_bands_chw` comes from GEE's empirical behaviour for the `reproject(crs=..., scale=...) + clip` call pattern rather than from Python-level normalization.
+
 ### Changed
 
 - **Normalization responsibility moved entirely to embedders.** `NormalizationSpec` has been removed from `ModelInputSpec` and from `rs_embed.core.specs`. The `apply_normalization()` helper in `rs_embed.providers.fetch` has been removed. `fetch_input()` and all fetch helpers (`fetch_collection_patch_chw`, `fetch_s2_rgb_chw`, `fetch_s2_multiframe_raw_tchw`, `fetch_s1_vvvh_raw_chw`) now consistently return raw provider values (S2 DN in [0, 10000], S1 linear float, etc.); each embedder applies its own normalization inside `get_embedding()`. This eliminates a misleading contract where `ModelInputSpec.normalization` was declared but never automatically applied, and removes a normalize→denormalize round-trip that existed in some batch paths (remoteclip, wildsat).

--- a/src/rs_embed/providers/gee.py
+++ b/src/rs_embed/providers/gee.py
@@ -15,6 +15,7 @@ from .gee_utils import (
     _build_s1_dualpol_collection,
     _collection_size_or_none,
     _fetch_with_bbox_fallback,
+    _flip_sample_tile_y,
     _format_s1_empty_collection_message,
     _gee_error_message,
     _gee_init_kwargs,
@@ -138,11 +139,17 @@ class GEEProvider(ProviderBase):
         fill_value: float,
         collection: str | None = None,
     ) -> np.ndarray:
-        """Download a rectangular patch as CHW array.
+        """Download a rectangular patch as **north-up** CHW float32.
 
-        - Resolves band aliases like BLUE/GREEN/RED -> B2/B3/B4 (S2) etc.
-        - Forces deterministic pixel grid by reprojecting to EPSG:3857 at `scale_m`
-          before sampleRectangle (prevents accidental (C,1,1)).
+        Uses ``ee.Projection.atScale()`` + ``.clip(region)`` before
+        ``sampleRectangle``.  That combination causes GEE to return rows in
+        south-up order, so ``_flip_sample_tile_y`` is applied here before
+        returning — callers always receive north-up output and must not flip
+        again.
+
+        Also resolves band aliases (BLUE/GREEN/RED → B2/B3/B4 for S2, etc.)
+        and clips to ``region`` so that pixels outside non-rectangular
+        geometries (e.g. PointBuffer) are filled with ``fill_value``.
         """
         import ee
 
@@ -155,11 +162,11 @@ class GEEProvider(ProviderBase):
         # 2) Select resolved bands (this will error at compute-time if typo)
         img = image.select(list(resolved))
 
-        # 3) Force pixel grid at desired scale
+        # 3) Force pixel grid at desired scale; clip masks non-rectangular regions
         proj = ee.Projection("EPSG:3857").atScale(int(scale_m))
         img = img.reproject(proj).clip(region)
 
-        # 4) Sample and build CHW
+        # 4) Sample and build CHW (raw GEE output is south-up with atScale+clip)
         rect = img.sampleRectangle(region=region, defaultValue=fill_value).getInfo()
         props = rect.get("properties", {})
         if not props:
@@ -180,7 +187,8 @@ class GEEProvider(ProviderBase):
                 f"Requested={resolved}. Available bands={avail}"
             )
 
-        return np.stack(arrs, axis=0)
+        # 5) Normalise to north-up: atScale+clip yields south-up rows from GEE
+        return _flip_sample_tile_y(np.stack(arrs, axis=0))
 
     def normalize_bands(
         self,
@@ -591,6 +599,9 @@ class GEEProvider(ProviderBase):
         else:
             raise ProviderError(f"Unknown composite='{composite}'. Use 'median' or 'mosaic'.")
 
+        # reproject(crs=..., scale=...) + clip: empirically north-up (matches
+        # _sample_image_bands_raw_chw's no-clip behaviour).  If this is ever
+        # found to be south-up, add _flip_sample_tile_y to the return value.
         img = img.reproject(crs="EPSG:3857", scale=int(scale_m)).clip(region)
         band_names_raw = img.bandNames().getInfo()
         band_names = tuple(str(b) for b in (band_names_raw or []))

--- a/src/rs_embed/providers/gee_utils.py
+++ b/src/rs_embed/providers/gee_utils.py
@@ -372,6 +372,20 @@ def _sample_image_bands_raw_chw(
     scale_m: int,
     fill_value: float,
 ) -> np.ndarray:
+    """Sample a GEE image as **north-up** CHW float32 in [0, 10_000].
+
+    GEE's ``sampleRectangle`` returns rows in north-to-south order when the
+    image is reprojected via ``reproject(crs=..., scale=...)`` **without** a
+    prior ``.clip()``.  This specific call pattern is what guarantees north-up
+    output here — no explicit flip is applied.
+
+    .. warning::
+        Do **not** add ``.clip(region)`` before ``sampleRectangle`` in this
+        function.  With the ``reproject(crs=..., scale=...)`` form, clipping
+        causes GEE to return south-up rows (the opposite convention), which
+        would silently invert every multiframe tile.  If masking of
+        non-rectangular regions is required, use ``fetch_array_chw`` instead.
+    """
     img = img.select(list(bands)).reproject(crs="EPSG:3857", scale=int(scale_m))
     rect = img.sampleRectangle(region=region, defaultValue=float(fill_value)).getInfo()
     props = rect.get("properties", {}) if isinstance(rect, dict) else {}
@@ -390,7 +404,18 @@ def _sample_image_bands_raw_chw(
 
 
 def _flip_sample_tile_y(arr: np.ndarray) -> np.ndarray:
-    """Normalize a fetched tile to north-up row order once at the leaf fetch."""
+    """Flip the penultimate (height) axis of a CHW or TCHW array from south-up to north-up.
+
+    Called by ``_fetch_provider_array_chw_with_bbox_fallback`` (the single-frame
+    leaf-fetch layer) to normalise the raw south-up output of
+    ``GEEProvider.fetch_array_chw``.  ``fetch_array_chw`` uses
+    ``ee.Projection.atScale() + .clip(region)`` before ``sampleRectangle``,
+    which causes GEE to return rows in south-up order.
+
+    ``_sample_image_bands_raw_chw`` uses a different call pattern
+    (``reproject(crs=..., scale=...)`` **without** clip) that already returns
+    north-up rows from GEE; applying this flip there would invert those tiles.
+    """
     a = np.asarray(arr, dtype=np.float32)
     if a.ndim < 2:
         raise ModelError(f"Expected fetched tile with spatial last2 dims, got shape={a.shape}")
@@ -486,15 +511,18 @@ def _fetch_provider_array_chw_with_bbox_fallback(
 ) -> np.ndarray:
     def _do(sp: SpatialSpec) -> np.ndarray:
         region = provider.get_region(sp)
-        arr = provider.fetch_array_chw(
-            image=image,
-            bands=bands,
-            region=region,
-            scale_m=int(scale_m),
-            fill_value=float(fill_value),
-            collection=collection,
+        # fetch_array_chw owns its orientation contract: always returns north-up.
+        return np.asarray(
+            provider.fetch_array_chw(
+                image=image,
+                bands=bands,
+                region=region,
+                scale_m=int(scale_m),
+                fill_value=float(fill_value),
+                collection=collection,
+            ),
+            dtype=np.float32,
         )
-        return _flip_sample_tile_y(np.asarray(arr, dtype=np.float32))
 
     return _fetch_with_bbox_fallback(
         spatial=spatial,

--- a/src/rs_embed/providers/gee_utils.py
+++ b/src/rs_embed/providers/gee_utils.py
@@ -406,11 +406,10 @@ def _sample_image_bands_raw_chw(
 def _flip_sample_tile_y(arr: np.ndarray) -> np.ndarray:
     """Flip the penultimate (height) axis of a CHW or TCHW array from south-up to north-up.
 
-    Called by ``_fetch_provider_array_chw_with_bbox_fallback`` (the single-frame
-    leaf-fetch layer) to normalise the raw south-up output of
-    ``GEEProvider.fetch_array_chw``.  ``fetch_array_chw`` uses
-    ``ee.Projection.atScale() + .clip(region)`` before ``sampleRectangle``,
-    which causes GEE to return rows in south-up order.
+    Called inside ``GEEProvider.fetch_array_chw``, which uses
+    ``ee.Projection.atScale() + .clip(region)`` before ``sampleRectangle``.
+    That call pattern causes GEE to return rows in south-up order, so the flip
+    is applied at the end of ``fetch_array_chw`` before returning to callers.
 
     ``_sample_image_bands_raw_chw`` uses a different call pattern
     (``reproject(crs=..., scale=...)`` **without** clip) that already returns

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -40,7 +40,8 @@ class _FakeBBoxSplitProvider(ProviderBase):
                 f"{self.max_pixels}. Got "
                 f"{h * w}."
             )
-        yy = np.arange(y0 + h - 1, y0 - 1, -1, dtype=np.float32)[:, None]
+        # fetch_array_chw contract: returns north-up CHW (row 0 = northernmost).
+        yy = np.arange(y0, y0 + h, dtype=np.float32)[:, None]
         xx = np.arange(x0, x0 + w, dtype=np.float32)[None, :]
         base = yy * 100.0 + xx
         out = np.stack([base + float(i) * 1000.0 for i in range(len(bands))], axis=0)
@@ -89,7 +90,8 @@ class _FakeBoundaryOverlapProvider(_FakeBBoxSplitProvider):
             if x0 + w < self.full_w:
                 w += 1
 
-        yy = np.arange(y0 + h - 1, y0 - 1, -1, dtype=np.float32)[:, None]
+        # fetch_array_chw contract: returns north-up CHW (row 0 = northernmost).
+        yy = np.arange(y0, y0 + h, dtype=np.float32)[:, None]
         xx = np.arange(x0, x0 + w, dtype=np.float32)[None, :]
         base = yy * 100.0 + xx
         out = np.stack([base + float(i) * 1000.0 for i in range(len(bands))], axis=0)
@@ -170,7 +172,7 @@ def test_fetch_provider_patch_raw_uses_generic_path_for_s1():
 
         def fetch_array_chw(self, *, image, bands, region, scale_m, fill_value, collection=None):
             self.fetch_calls += 1
-            # Return south-up array (will be flipped by _flip_sample_tile_y)
+            # fetch_array_chw contract: return north-up CHW.
             return np.arange(2 * 3 * 4, dtype=np.float32).reshape(2, 3, 4)
 
     provider = _FakeGenericS1Provider()
@@ -194,7 +196,7 @@ def test_fetch_provider_patch_raw_uses_generic_path_for_s1():
     assert provider.fetch_calls == 1
 
 
-def test_fetch_provider_patch_raw_flips_single_south_up_tile_before_return():
+def test_fetch_provider_patch_raw_returns_north_up_tile():
     provider = _FakeBBoxSplitProvider()
     sensor = SensorSpec(collection="FAKE/COLL", bands=("B1",), scale_m=75000, fill_value=0.0)
     spatial = BBox(minlon=0.0, minlat=0.0, maxlon=2.0, maxlat=1.0)
@@ -230,7 +232,7 @@ def test_fetch_provider_patch_raw_trims_boundary_overlap_when_stitching():
     np.testing.assert_allclose(arr, expected)
 
 
-def test_fetch_provider_patch_raw_flips_south_up_tiles_for_y_stitch():
+def test_fetch_provider_patch_raw_correctly_stitches_y_split_tiles():
     provider = _FakeVerticalSouthUpProvider()
     sensor = SensorSpec(collection="FAKE/COLL", bands=("B1",), scale_m=75000, fill_value=0.0)
 
@@ -249,7 +251,7 @@ def test_fetch_provider_patch_raw_flips_south_up_tiles_for_y_stitch():
     np.testing.assert_allclose(arr, expected)
 
 
-def test_fetch_provider_patch_raw_flips_south_up_tiles_across_recursive_y_stitch():
+def test_fetch_provider_patch_raw_correctly_stitches_recursive_y_split_tiles():
     provider = _FakeDeepVerticalSouthUpProvider()
     sensor = SensorSpec(collection="FAKE/COLL", bands=("B1",), scale_m=75000, fill_value=0.0)
 

--- a/tests/test_gee_provider.py
+++ b/tests/test_gee_provider.py
@@ -668,3 +668,96 @@ def test_fetch_s1_vvvh_raw_chw_relaxes_iw_and_reports_meta(monkeypatch):
     assert meta["s1_iw_requested"] is True
     assert meta["s1_iw_applied"] is False
     assert meta["s1_iw_relaxed_on_empty"] is True
+
+
+# ══════════════════════════════════════════════════════════════════════
+# _fetch_all_bands_impl — orientation contract
+# ══════════════════════════════════════════════════════════════════════
+
+
+def test_fetch_all_bands_impl_passes_through_gee_row_order(monkeypatch):
+    """Orientation contract test for _fetch_all_bands_impl.
+
+    The function applies **no** spatial flip — it passes through whatever row
+    order GEE's ``sampleRectangle`` returns.  For the
+    ``reproject(crs=..., scale=...) + .clip()`` call pattern used here, GEE
+    empirically returns north-up rows (row 0 = northernmost).  This test locks
+    in the pass-through behaviour so that any accidental flip addition would be
+    caught immediately.
+
+    The mock injects two distinguishable rows:
+      row 0 → [1, 2]   (northernmost row, per the empirical GEE convention)
+      row 1 → [3, 4]   (southernmost row)
+
+    We assert the output preserves this exact order.  If GEE is ever found to
+    return south-up for this pattern, add ``_flip_sample_tile_y`` to
+    ``_fetch_all_bands_impl`` **and** update this test to expect the flipped
+    order.
+    """
+    import numpy as np
+
+    from rs_embed.core.specs import BBox, TemporalSpec
+
+    # ── GEE pixel data: row 0 = [1, 2], row 1 = [3, 4] ────────────────
+    _NORTH_ROW = [1.0, 2.0]
+    _SOUTH_ROW = [3.0, 4.0]
+
+    class _FakeImage:
+        def reproject(self, **_kw):
+            return self
+
+        def clip(self, _region):
+            return self
+
+        def bandNames(self):
+            class _Names:
+                def getInfo(self):
+                    return ["B1"]
+
+            return _Names()
+
+        def sampleRectangle(self, **_kw):
+            class _Rect:
+                def getInfo(self):
+                    return {"properties": {"B1": [_NORTH_ROW, _SOUTH_ROW]}}
+
+            return _Rect()
+
+    class _FakeCollection:
+        def filterBounds(self, _r):
+            return self
+
+        def filterDate(self, _s, _e):
+            return self
+
+        def size(self):
+            class _Size:
+                def getInfo(self):
+                    return 1
+
+            return _Size()
+
+        def median(self):
+            return _FakeImage()
+
+    fake_ee = types.SimpleNamespace(ImageCollection=lambda _c: _FakeCollection())
+    monkeypatch.setitem(sys.modules, "ee", fake_ee)
+
+    provider = GEEProvider(auto_auth=False)
+    monkeypatch.setattr(provider, "ensure_ready", lambda: None)
+    monkeypatch.setattr(provider, "get_region", lambda _spatial: object())
+
+    arr, names = provider._fetch_all_bands_impl(
+        spatial=BBox(minlon=0.0, minlat=0.0, maxlon=1.0, maxlat=1.0),
+        temporal=TemporalSpec.year(2024),
+        collection="FAKE/COLL",
+        scale_m=10,
+        fill_value=0.0,
+    )
+
+    assert names == ("B1",)
+    assert arr.shape == (1, 2, 2)
+    # Row order is preserved as-is from GEE — no flip applied.
+    # Empirically GEE returns north-up for this call pattern, so row 0 = northernmost.
+    np.testing.assert_allclose(arr[0, 0], _NORTH_ROW)
+    np.testing.assert_allclose(arr[0, 1], _SOUTH_ROW)


### PR DESCRIPTION
## Summary

* Fix ModuleNotFoundError when importing rs_embed.cli
* Clarify and enforce north-up orientation contract across all GEE fetch paths
* Add orientation regression test for _fetch_all_bands_impl

Refactor — GEE tile orientation

Previously, GEEProvider.fetch_array_chw returned south-up raw data and the flip was applied by its caller (_fetch_provider_array_chw_with_bbox_fallback). This was a leaky abstraction: any subclass overriding fetch_array_chw had to know to return south-up or risk being flipped twice.

fetch_array_chw now applies _flip_sample_tile_y internally and contracts to return north-up CHW. The caller no longer flips.

The _sample_image_bands_raw_chw docstring documents why no flip is needed there: reproject(crs=..., scale=...) without .clip() already produces north-up rows from GEE, and adding .clip() would silently invert the row order and break the multiframe (TCHW) path.


## Testing

Fake provider fetch_array_chw implementations in test_api_helpers.py updated to return north-up data directly, matching the new contract; 3 test functions renamed to remove references to "flipping south-up tiles"

test_gee_provider.py: added test_fetch_all_bands_impl_passes_through_gee_row_order to lock in the pass-through behaviour of _fetch_all_bands_impl and document that its north-up guarantee comes from GEE's empirical API behaviour, not from Python-level normalization

- [x] I ran the relevant tests locally.
- [ ] I updated docs for user-facing behavior changes.
- [x] I updated `CHANGELOG.md` for user-facing API, model, semantic, or installation changes.
- [ ] This PR does not need a changelog entry.

## Notes

Anything reviewers should know about scope, tradeoffs, or follow-up work.
