### PR TITLE
fix: skip all-NaN frames in multi-frame fetch inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on Keep a Changelog, and the project follows Semantic Versio
 
 ### Fixed
 
-- **`export_batch` emitted spurious `All-NaN slice` / `Mean of empty slice` RuntimeWarnings for multi-temporal models with an empty leading temporal bin.** The prefetch input inspection (`inspect_fetch_result`) inspected frame 0 of a multi-frame `[T,C,H,W]` stack unconditionally; when that bin had no usable imagery (a NaN-sentinel frame that the embedder drops downstream), the per-band nan-reductions warned over an all-NaN frame. It now inspects the first frame carrying finite data, falling back to frame 0 only when every frame is empty (still flagged `ok=False`), and reports the chosen frame via a new `inspected_frame` field. Only the prefetch/export path runs this inspection, so `get_embedding`/`get_embeddings_batch` were never affected.
+- **`export_batch` emitted spurious `All-NaN slice` RuntimeWarnings for multi-temporal models with an empty leading temporal bin.** Input inspection now stats the first frame with finite data instead of a blind frame 0.
 
 ## [0.2.0] — 2026-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on Keep a Changelog, and the project follows Semantic Versio
 
 - **`satmaepp_s2_10b` is no longer a standalone model; the Sentinel-2 10-band path is now the `"s2_10b"` modality of `satmaepp`.** SatMAE++'s two sensor configurations live under one model name, selected with `modality=` (the codebase's mechanism for same-model/different-sensor, like `terrafm`'s s2/s1): `get_embedding("satmaepp")` is the default fMoW-RGB 3-band path and `get_embedding("satmaepp", modality="s2_10b")` is the grouped-channel 10-band path; for exports use `export_batch(..., per_model_modalities={"satmaepp": "s2_10b"})`. The `satmaepp_s2_10b`, `satmaepp_s2`, and `satmaepp_sentinel10` model names (and their `variant`/env knobs) are removed — **migrate to `modality="s2_10b"`.** Embeddings and metadata for the 10-band path are unchanged (now labelled under `model="satmaepp"`); the model catalog drops from 20 to 19 entries.
 
+### Fixed
+
+- **`export_batch` emitted spurious `All-NaN slice` / `Mean of empty slice` RuntimeWarnings for multi-temporal models with an empty leading temporal bin.** The prefetch input inspection (`inspect_fetch_result`) inspected frame 0 of a multi-frame `[T,C,H,W]` stack unconditionally; when that bin had no usable imagery (a NaN-sentinel frame that the embedder drops downstream), the per-band nan-reductions warned over an all-NaN frame. It now inspects the first frame carrying finite data, falling back to frame 0 only when every frame is empty (still flagged `ok=False`), and reports the chosen frame via a new `inspected_frame` field. Only the prefetch/export path runs this inspection, so `get_embedding`/`get_embeddings_batch` were never affected.
+
 ## [0.2.0] — 2026-06-29
 
 This release adds the OlmoEarth model family, makes the temporal models (`prithvi`, `galileo`, `olmoearth`) sample window-adaptively by default, and fixes several `export_batch` correctness issues where a point's embedding differed between the single and batch/tiled paths. Some defaults that change embedding behavior are noted below; pin explicit options where strict reproducibility across versions is required.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,7 @@ The format is based on Keep a Changelog, and the project follows Semantic Versio
 
 - **`satmaepp_s2_10b` is no longer a standalone model; the Sentinel-2 10-band path is now the `"s2_10b"` modality of `satmaepp`.** SatMAE++'s two sensor configurations live under one model name, selected with `modality=` (the codebase's mechanism for same-model/different-sensor, like `terrafm`'s s2/s1): `get_embedding("satmaepp")` is the default fMoW-RGB 3-band path and `get_embedding("satmaepp", modality="s2_10b")` is the grouped-channel 10-band path; for exports use `export_batch(..., per_model_modalities={"satmaepp": "s2_10b"})`. The `satmaepp_s2_10b`, `satmaepp_s2`, and `satmaepp_sentinel10` model names (and their `variant`/env knobs) are removed — **migrate to `modality="s2_10b"`.** Embeddings and metadata for the 10-band path are unchanged (now labelled under `model="satmaepp"`); the model catalog drops from 20 to 19 entries.
 
-### Fixed
-
-- **`export_batch` emitted spurious `All-NaN slice` RuntimeWarnings for multi-temporal models with an empty leading temporal bin.** Input inspection now stats the first frame with finite data instead of a blind frame 0.
-
-## [0.2.0] — 2026-06-29
+## [0.2.0] — 2026-06-30
 
 This release adds the OlmoEarth model family, makes the temporal models (`prithvi`, `galileo`, `olmoearth`) sample window-adaptively by default, and fixes several `export_batch` correctness issues where a point's embedding differed between the single and batch/tiled paths. Some defaults that change embedding behavior are noted below; pin explicit options where strict reproducibility across versions is required.
 
@@ -47,6 +43,7 @@ This release adds the OlmoEarth model family, makes the temporal models (`prithv
 - **Multi-temporal models no longer silently hide how many distinct frames a window actually had.** All five temporal adapters (`olmoearth`, `galileo`, `prithvi`, `anysat`, `agrifm`) now record frame-diversity metadata (`n_distinct_frames`/`n_backfilled_frames`, or `n_bins`/`dropped_bins` for `olmoearth`) and emit a `UserWarning` when real frames are sparser than requested — across the single, tiled, batch, and `export_batch` paths.
 - **`prithvi` no longer silently degrades to a single composite on the `tile`/`auto`/`export_batch` paths.** It now overrides `fetch_input` to prefetch the same window-adaptive `[T,6,H,W]` raw-DN series as the direct path (single-frame windows defer to the generic composite fetch), so `num_frames` is identical across all APIs.
 - **`olmoearth` `temporal_mode="multi"` silently dropped everything beyond the first ~12 months.** Windows over ~1 year are now equal-divided into 12 frames covering the whole period, surfaced via `temporal_sampling="equal_divided"` and a `UserWarning`; ≤12-month windows keep the in-distribution 30-day cadence.
+- **`export_batch` emitted spurious `All-NaN slice` RuntimeWarnings for multi-temporal models with an empty leading temporal bin.** Input inspection now stats the first frame with finite data instead of a blind frame 0.
 - **`remoteclip` `pooled` output was inconsistent between single and batch/tiled paths** (768-d raw token mean vs 512-d projected CLIP). The single path now also uses `encode_image`, so `pooled` is the canonical 512-d CLIP embedding everywhere, and `grid` extraction was unified across paths.
 - **Combined `export_batch` manifest lost all but the first model entry.** `combined_write_checkpoint` returned a copy instead of the caller's mutated dict, dropping every model after the first; it now merges the writer's path keys back into the original manifest. Per-item exports were unaffected.
 - **`tessera` no longer re-fetches every tile twice per point.** `_mosaic_and_crop_strict_roi` invoked its `tiles_rows_factory` twice (re-downloading on a cold cache); the factory is now materialized once and shared, roughly halving first-chunk I/O at the cost of holding the point's tile blocks in memory simultaneously.
@@ -56,6 +53,7 @@ This release adds the OlmoEarth model family, makes the temporal models (`prithv
 - **`gse` batch inference now runs concurrently on CPU in `export_batch`** instead of only when a GPU was detected, benefiting precomputed models that do their own remote IO.
 - **`get_embedding`/`get_embeddings_batch` no longer raise on `input_prep='tile'` with `model='gse'`, and `export_batch` no longer ignores `input_prep` for GSE.** All now emit a `UserWarning` clarifying that GSE manages its own tiling.
 - **`input_prep='tile'` no longer disables `get_embeddings_batch` for precomputed models in `export_batch`.** The `allow_nonresize` guard now applies only to prefetched-input batch APIs; no-input batch APIs are unaffected.
+
 
 ## [0.1.3] — 2026-04-12
 

--- a/src/rs_embed/providers/fetch.py
+++ b/src/rs_embed/providers/fetch.py
@@ -470,7 +470,19 @@ def inspect_fetch_result(
     from ..tools.serialization import jsonable as _jsonable
 
     x = normalize_input_array(x_chw, expected_channels=len(sensor.bands), name=name)
-    x_inspect = x[0] if x.ndim == 4 else x
+    inspected_frame: int | None = None
+    if x.ndim == 4:
+        # Multi-frame (TCHW): empty temporal bins are NaN-sentinel frames that the
+        # embedder drops downstream. Inspect the first frame that carries any finite
+        # data instead of a blind x[0], so an all-NaN sentinel doesn't trigger
+        # spurious "All-NaN slice" / "Mean of empty slice" warnings in inspect_chw.
+        inspected_frame = next(
+            (i for i in range(int(x.shape[0])) if np.isfinite(x[i]).any()),
+            0,  # all frames empty -> fall back to frame 0 so inspect_chw flags it
+        )
+        x_inspect = x[inspected_frame]
+    else:
+        x_inspect = x
     rep = inspect_chw(
         x_inspect,
         name=name,
@@ -484,4 +496,5 @@ def inspect_fetch_result(
         "sensor": _jsonable(sensor),
         "input_ndim": int(x.ndim),
         "n_frames": (int(x.shape[0]) if x.ndim == 4 else None),
+        "inspected_frame": inspected_frame,
     }

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -39,3 +39,35 @@ def test_inspect_gee_patch_uses_shared_fetch_helper(monkeypatch):
     assert calls["direct"] == 0
     assert out["array_chw"].shape == (1, 2, 3)
     assert out["backend"] == "gee"
+
+
+def test_inspect_fetch_result_skips_all_nan_leading_frame(recwarn):
+    """A TCHW stack whose first frame is an empty (all-NaN) temporal bin must be
+    inspected via the first finite frame, not frame 0 — so no NaN-reduction
+    RuntimeWarning leaks out and the report reflects real imagery."""
+    from rs_embed.providers import fetch as fetch_mod
+
+    sensor = SensorSpec(collection="FAKE/COLL", bands=("B1", "B2"))
+    x_tchw = np.full((3, 2, 8, 8), np.nan, dtype=np.float32)
+    x_tchw[1] = 1500.0  # only the second bin had usable imagery
+
+    out = fetch_mod.inspect_fetch_result(x_tchw, sensor=sensor, name="t")
+
+    assert out["inspected_frame"] == 1
+    assert out["n_frames"] == 3
+    assert out["report"]["finite_frac"] == 1.0
+    assert not any(w.category is RuntimeWarning for w in recwarn.list)
+
+
+def test_inspect_fetch_result_all_empty_frames_falls_back_to_frame_zero():
+    """If every frame is empty there is no finite frame to pick; fall back to
+    frame 0 so inspect_chw still flags the bad input rather than indexing past."""
+    from rs_embed.providers import fetch as fetch_mod
+
+    sensor = SensorSpec(collection="FAKE/COLL", bands=("B1", "B2"))
+    x_tchw = np.full((2, 2, 4, 4), np.nan, dtype=np.float32)
+
+    out = fetch_mod.inspect_fetch_result(x_tchw, sensor=sensor, name="t")
+
+    assert out["inspected_frame"] == 0
+    assert out["ok"] is False


### PR DESCRIPTION
## What

`inspect_fetch_result` blindly inspected frame 0 of a multi-frame (TCHW) prefetch stack. For multi-temporal models (e.g. OlmoEarth), empty temporal bins are NaN-sentinel frames that the embedder drops downstream. When the **leading** bin was empty, `inspect_chw` ran `np.nanmin/nanmax/nanmean` over an all-NaN frame and emitted spurious `All-NaN slice` / `Mean of empty slice` / `Degrees of freedom <= 0` RuntimeWarnings during `export_batch`.

## Fix

Pick the first frame carrying finite data instead of a blind `x[0]`, falling back to frame 0 only when every frame is empty (so genuinely bad input is still flagged `ok=False`). The chosen frame index is reported via a new `inspected_frame` field.

Only the prefetch/export path runs this inspection, which is why `get_embedding` / `get_embeddings_batch` never showed the warnings — only `export_batch` did.

## Tests

- New regression tests in `tests/test_inspect.py`:
  - all-NaN leading frame → inspects the first finite frame, no RuntimeWarning, `inspected_frame == 1`.
  - all frames empty → falls back to frame 0 and still reports `ok=False`.
- `tests/ -k "fetch or inspect"`: 150 passed, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)