### PR TITLE
feat(olmoearth): integrate OlmoEarth v1.2 (nano/tiny/small/base)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,12 @@ The format is based on Keep a Changelog, and the project follows Semantic Versio
 
 ### Added
 
-- **OlmoEarth v1.2 variants (`nano_v1_2`/`tiny_v1_2`/`small_v1_2`/`base_v1_2`).** Adds the v1.2 OlmoEarth family (Allen AI), including a new `small` size (384-d); dims are 128/192/384/768. v1.2 is not released in a `large` size. Selectable via `variant=`/`model_config`, with short aliases `nano_12`/`tiny_12`/`small_12`/`base_12` (and the bare `small`, which is v1.2-only). Requires `olmoearth-pretrain-minimal>=0.0.6`, which registers the `v1_2` model ids.
+- **OlmoEarth v1.2 variants (`nano_v1_2`/`tiny_v1_2`/`small_v1_2`/`base_v1_2`, incl. a new 384-d `small`).** Requires `olmoearth-pretrain-minimal>=0.0.6`.
 
 ### Changed
 
 - **`satmaepp_s2_10b` is no longer a standalone model; the Sentinel-2 10-band path is now the `"s2_10b"` modality of `satmaepp`.** SatMAE++'s two sensor configurations live under one model name, selected with `modality=` (the codebase's mechanism for same-model/different-sensor, like `terrafm`'s s2/s1): `get_embedding("satmaepp")` is the default fMoW-RGB 3-band path and `get_embedding("satmaepp", modality="s2_10b")` is the grouped-channel 10-band path; for exports use `export_batch(..., per_model_modalities={"satmaepp": "s2_10b"})`. The `satmaepp_s2_10b`, `satmaepp_s2`, and `satmaepp_sentinel10` model names (and their `variant`/env knobs) are removed — **migrate to `modality="s2_10b"`.** Embeddings and metadata for the 10-band path are unchanged (now labelled under `model="satmaepp"`); the model catalog drops from 20 to 19 entries.
-- **`olmoearth` default variant changed `tiny_v1_1` → `base_v1_2`.** The default model is now OlmoEarth v1.2 Base (768-d). To keep the previous default, pass `variant="tiny_v1_1"` (or set `RS_EMBED_OLMOEARTH_VARIANT`).
+- **`olmoearth` default variant is now `base_v1_2` (was `tiny_v1_1`).** Pin `variant="tiny_v1_1"` to keep the old default.
 
 ## [0.2.0] — 2026-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,22 +8,17 @@ The format is based on Keep a Changelog, and the project follows Semantic Versio
 
 ## [Unreleased]
 
-### Added
-
-- **OlmoEarth v1.2 variants (`nano_v1_2`/`tiny_v1_2`/`small_v1_2`/`base_v1_2`, incl. a new 384-d `small`).** Requires `olmoearth-pretrain-minimal>=0.0.6`.
-
 ### Changed
 
 - **`satmaepp_s2_10b` is no longer a standalone model; the Sentinel-2 10-band path is now the `"s2_10b"` modality of `satmaepp`.** SatMAE++'s two sensor configurations live under one model name, selected with `modality=` (the codebase's mechanism for same-model/different-sensor, like `terrafm`'s s2/s1): `get_embedding("satmaepp")` is the default fMoW-RGB 3-band path and `get_embedding("satmaepp", modality="s2_10b")` is the grouped-channel 10-band path; for exports use `export_batch(..., per_model_modalities={"satmaepp": "s2_10b"})`. The `satmaepp_s2_10b`, `satmaepp_s2`, and `satmaepp_sentinel10` model names (and their `variant`/env knobs) are removed — **migrate to `modality="s2_10b"`.** Embeddings and metadata for the 10-band path are unchanged (now labelled under `model="satmaepp"`); the model catalog drops from 20 to 19 entries.
-- **`olmoearth` default variant is now `base_v1_2` (was `tiny_v1_1`).** Pin `variant="tiny_v1_1"` to keep the old default.
 
-## [0.2.0] — 2026-06-29
+## [0.2.0] — 2026-06-30
 
 This release adds the OlmoEarth model family, makes the temporal models (`prithvi`, `galileo`, `olmoearth`) sample window-adaptively by default, and fixes several `export_batch` correctness issues where a point's embedding differed between the single and batch/tiled paths. Some defaults that change embedding behavior are noted below; pin explicit options where strict reproducibility across versions is required.
 
 ### Added
 
-- **OlmoEarth v1/v1.1 embedder (`olmoearth`).** Adds the [OlmoEarth](https://huggingface.co/collections/allenai/olmoearth) foundation model family (Allen AI), all 7 variants (`nano`/`tiny`/`base`/`large` v1, `nano_v1_1`/`tiny_v1_1`/`base_v1_1` v1.1; dims 128/192/768/1024), encoding 12 Sentinel-2 L2A bands with the FlexiViT encoder. Both `pooled` and `grid` outputs are supported; requires `pip install rs-embed[olmoearth]`.
+- **OlmoEarth v1/v1.1/v1.2 embedder (`olmoearth`).** Adds the [OlmoEarth](https://huggingface.co/collections/allenai/olmoearth) foundation model family (Allen AI): v1 `nano`/`tiny`/`base`/`large`, v1.1 `nano_v1_1`/`tiny_v1_1`/`base_v1_1`, and v1.2 `nano_v1_2`/`tiny_v1_2`/`small_v1_2`/`base_v1_2` (default `base_v1_2`; dims 128/192/384/768/1024), encoding 12 Sentinel-2 L2A bands with the FlexiViT encoder. Both `pooled` and `grid` outputs are supported; requires `pip install rs-embed[olmoearth]` (`olmoearth-pretrain-minimal>=0.0.6`).
 - **Multi-frame temporal mode for Prithvi (`temporal_mode="multi"`).** A new `temporal_mode` key (default `"auto"`) feeds Prithvi-EO 2.0 a real multi-timestep HLS series instead of always collapsing the window into a single median composite; the frame count is derived from the window (`T = clamp(window_days // 28, 1, max_frames)`, default `max_frames=4`) and output shapes are unchanged. Configurable via `model_config` or `RS_EMBED_PRITHVI_*` env vars.
 - **`gse` now automatically tiles large spatial requests.** When a `BBox`'s estimated pixel footprint exceeds the GEE `sampleRectangle` limit, the region is split into a sub-BBox grid, each tile fetched and concatenated — removing the previous hard cap on request size while matching a single large fetch.
 - **GEE fetch statistics reporting in `export_batch`.** With `show_progress=True`, a thread-safe `[gee_fetch]` summary line (planned / completed / failed / cache-hit counts) is printed to stderr after each prefetch chunk, giving visibility into GEE quota use and cache reuse.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,14 @@ The format is based on Keep a Changelog, and the project follows Semantic Versio
 
 ## [Unreleased]
 
+### Added
+
+- **OlmoEarth v1.2 variants (`nano_v1_2`/`tiny_v1_2`/`small_v1_2`/`base_v1_2`).** Adds the v1.2 OlmoEarth family (Allen AI), including a new `small` size (384-d); dims are 128/192/384/768. v1.2 is not released in a `large` size. Selectable via `variant=`/`model_config`, with short aliases `nano_12`/`tiny_12`/`small_12`/`base_12` (and the bare `small`, which is v1.2-only). Requires `olmoearth-pretrain-minimal>=0.0.6`, which registers the `v1_2` model ids.
+
 ### Changed
 
 - **`satmaepp_s2_10b` is no longer a standalone model; the Sentinel-2 10-band path is now the `"s2_10b"` modality of `satmaepp`.** SatMAE++'s two sensor configurations live under one model name, selected with `modality=` (the codebase's mechanism for same-model/different-sensor, like `terrafm`'s s2/s1): `get_embedding("satmaepp")` is the default fMoW-RGB 3-band path and `get_embedding("satmaepp", modality="s2_10b")` is the grouped-channel 10-band path; for exports use `export_batch(..., per_model_modalities={"satmaepp": "s2_10b"})`. The `satmaepp_s2_10b`, `satmaepp_s2`, and `satmaepp_sentinel10` model names (and their `variant`/env knobs) are removed — **migrate to `modality="s2_10b"`.** Embeddings and metadata for the 10-band path are unchanged (now labelled under `model="satmaepp"`); the model catalog drops from 20 to 19 entries.
+- **`olmoearth` default variant changed `tiny_v1_1` → `base_v1_2`.** The default model is now OlmoEarth v1.2 Base (768-d). To keep the previous default, pass `variant="tiny_v1_1"` (or set `RS_EMBED_OLMOEARTH_VARIANT`).
 
 ## [0.2.0] — 2026-06-29
 

--- a/docs/models/olmoearth.md
+++ b/docs/models/olmoearth.md
@@ -5,9 +5,9 @@
 | Field                | Value                                                                                                     |
 | -------------------- | --------------------------------------------------------------------------------------------------------- |
 | Model ID             | `olmoearth`                                                                                               |
-| Family / Backbone    | OlmoEarth v1/v1.1 — FlexiViT encoder (ViT-style) trained on the Major TOM dataset                       |
+| Family / Backbone    | OlmoEarth v1/v1.1/v1.2 — FlexiViT encoder (ViT-style) trained on the Major TOM dataset                  |
 | Adapter type         | `on-the-fly`                                                                                              |
-| Model config keys    | `variant` (default: `tiny_v1_1`), `patch_size` (default: `4`), `image_size` (default: `256`), `shape_adjust` (default: `pad`) |
+| Model config keys    | `variant` (default: `base_v1_2`), `patch_size` (default: `4`), `image_size` (default: `256`), `shape_adjust` (default: `pad`) |
 | Training alignment   | High (S2 L2A 12-band; native 10 m resolution; per-band mean±2σ normalization matches training pipeline)   |
 
 !!! success "OlmoEarth In 30 Seconds"
@@ -98,12 +98,18 @@ Selects the model size and version. Weights are automatically downloaded from Hu
 | `nano_v1_1`  | v1.1    | 128         | 4     | `allenai/OlmoEarth-v1_1-Nano`      |
 | `tiny_v1_1`  | v1.1    | 192         | 12    | `allenai/OlmoEarth-v1_1-Tiny`      |
 | `base_v1_1`  | v1.1    | 768         | 12    | `allenai/OlmoEarth-v1_1-Base`      |
+| `nano_v1_2`  | v1.2    | 128         | 4     | `allenai/OlmoEarth-v1_2-Nano`      |
+| `tiny_v1_2`  | v1.2    | 192         | 12    | `allenai/OlmoEarth-v1_2-Tiny`      |
+| `small_v1_2` | v1.2    | 384         | 12    | `allenai/OlmoEarth-v1_2-Small`     |
+| `base_v1_2`  | v1.2    | 768         | 12    | `allenai/OlmoEarth-v1_2-Base`      |
 
-!!! note "v1 vs v1.1 architecture difference"
+The default variant is **`base_v1_2`**. v1.2 requires `olmoearth-pretrain-minimal>=0.0.6`.
+
+!!! note "v1 vs v1.1/v1.2 architecture difference"
     v1 uses a Conv2D-based patch embedding, producing 3 separate band-set token groups per spatial location.
-    v1.1 uses a linear patch embedding (`use_linear_patch_embed=True`) that merges band sets into a single token stream. Both versions produce the same output dimensionality after pooling.
+    v1.1 and v1.2 use a linear patch embedding (`use_linear_patch_embed=True`) that merges band sets into a single token stream. All versions produce the same output dimensionality after pooling. v1.2 adds a new `small` size (384-d) and is not released in a `large` size.
 
-Short aliases are accepted: `nano_11`, `tiny_11`, `base_11` for v1.1 variants; `nano_v1`, `tiny_v1`, `base_v1`, `large_v1` for v1 variants.
+Short aliases are accepted: `nano_12`, `tiny_12`, `small_12`, `base_12` (and the bare `small`, which is v1.2-only) for v1.2 variants; `nano_11`, `tiny_11`, `base_11` for v1.1 variants; `nano_v1`, `tiny_v1`, `base_v1`, `large_v1` for v1 variants.
 
 ### `patch_size`
 
@@ -218,7 +224,7 @@ For defaults (256, patch_size=4): `64 × 64` grid.
 
 | Variable                         | Default  | Effect                                              |
 | -------------------------------- | -------- | --------------------------------------------------- |
-| `RS_EMBED_OLMOEARTH_VARIANT`     | `tiny_v1_1`   | Default model variant when `model_config` not given |
+| `RS_EMBED_OLMOEARTH_VARIANT`     | `base_v1_2`   | Default model variant when `model_config` not given |
 | `RS_EMBED_OLMOEARTH_PATCH_SIZE`  | `4`      | Default patch size when `model_config` not given    |
 | `RS_EMBED_OLMOEARTH_IMAGE_SIZE`  | `256`    | Default image resize target                         |
 | `RS_EMBED_OLMOEARTH_SHAPE_ADJUST` | `pad`   | How non-square ROIs are made square (`pad` / `crop`) |
@@ -267,7 +273,7 @@ emb = get_embedding(
     temporal=TemporalSpec.range("2022-06-01", "2022-09-01"),
     output=OutputSpec.grid(),
     backend="gee",
-    variant="tiny_v1_1",
+    variant="tiny_v1_2",
     modality="s1",
 )
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,12 +69,12 @@ terramind = [
   "terratorch==1.2.1",
 ]
 olmoearth = [
-  "olmoearth-pretrain-minimal>=0.0.5",
+  "olmoearth-pretrain-minimal>=0.0.6",
 ]
 full = [
   "matplotlib>=3.10",
   "terratorch==1.2.1",
-  "olmoearth-pretrain-minimal>=0.0.5",
+  "olmoearth-pretrain-minimal>=0.0.6",
 ]
 dev = [
   "pytest>=7.4",

--- a/src/rs_embed/embedders/onthefly_olmoearth.py
+++ b/src/rs_embed/embedders/onthefly_olmoearth.py
@@ -87,6 +87,10 @@ _VARIANT_SPECS: dict[str, tuple[str, str, str]] = {
     "nano_v1_1": ("OlmoEarth-v1_1-Nano", "nano", "v1.1"),
     "tiny_v1_1": ("OlmoEarth-v1_1-Tiny", "tiny", "v1.1"),
     "base_v1_1": ("OlmoEarth-v1_1-Base", "base", "v1.1"),
+    "nano_v1_2": ("OlmoEarth-v1_2-Nano", "nano", "v1.2"),
+    "tiny_v1_2": ("OlmoEarth-v1_2-Tiny", "tiny", "v1.2"),
+    "small_v1_2": ("OlmoEarth-v1_2-Small", "small", "v1.2"),
+    "base_v1_2": ("OlmoEarth-v1_2-Base", "base", "v1.2"),
 }
 
 _VARIANT_ALIASES: dict[str, str] = {
@@ -97,9 +101,15 @@ _VARIANT_ALIASES: dict[str, str] = {
     "nano_11": "nano_v1_1",
     "tiny_11": "tiny_v1_1",
     "base_11": "base_v1_1",
+    "nano_12": "nano_v1_2",
+    "tiny_12": "tiny_v1_2",
+    "small_12": "small_v1_2",
+    "base_12": "base_v1_2",
+    # "small" exists only in v1.2, so the bare size name is unambiguous.
+    "small": "small_v1_2",
 }
 
-_DEFAULT_VARIANT = "tiny_v1_1"
+_DEFAULT_VARIANT = "base_v1_2"
 _DEFAULT_IMAGE_SIZE = 256  # training tile size; model accepts any size divisible by patch_size
 _DEFAULT_PATCH_SIZE = 4
 # OlmoEarth's positional encoding requires a square token grid, so a rectangular
@@ -706,7 +716,7 @@ def _tokens_to_grid(tokens_and_masks, pooling: str, *, modality: str = "s2") -> 
 
 @register("olmoearth")
 class OlmoEarthEmbedder(EmbedderBase):
-    """OlmoEarth v1/v1.1 on-the-fly embeddings from S2 L2A 12-band or S1 VV/VH patches.
+    """OlmoEarth v1/v1.1/v1.2 on-the-fly embeddings from S2 L2A 12-band or S1 VV/VH patches.
 
     Inputs:
       - spatial : BBox / PointBuffer (EPSG:4326)
@@ -731,6 +741,9 @@ class OlmoEarthEmbedder(EmbedderBase):
     Model variants (via ``model_config={"variant": "..."}``):
       v1  : nano (128-d), tiny (192-d), base (768-d), large (1024-d)
       v1.1: nano_v1_1 (128-d), tiny_v1_1 (192-d), base_v1_1 (768-d)
+      v1.2: nano_v1_2, tiny_v1_2, small_v1_2, base_v1_2 (default; ``small``
+            is v1.2-only). Embedding width is read from the model output, so
+            new sizes need no dim wiring here.
     """
 
     # Square-input model: marks it for the API tiling path (its own fetch_input

--- a/tests/test_olmoearth.py
+++ b/tests/test_olmoearth.py
@@ -33,6 +33,15 @@ from rs_embed.embedders import onthefly_olmoearth as oe
         ("tiny_11", "tiny_v1_1"),
         ("base_v1_1", "base_v1_1"),
         ("base_11", "base_v1_1"),
+        ("nano_v1_2", "nano_v1_2"),
+        ("tiny_v1_2", "tiny_v1_2"),
+        ("small_v1_2", "small_v1_2"),
+        ("base_v1_2", "base_v1_2"),
+        ("BASE_V1_2", "base_v1_2"),
+        ("base_12", "base_v1_2"),
+        ("small_12", "small_v1_2"),
+        ("small", "small_v1_2"),  # "small" is v1.2-only
+        ("base-v1.2", "base_v1_2"),  # dashes/dots normalized to underscores
     ],
 )
 def test_normalize_variant_valid(raw, expected):
@@ -54,9 +63,9 @@ def test_resolve_variant_from_model_config():
     assert oe._resolve_variant({"variant": "nano_v1_1"}) == "nano_v1_1"
 
 
-def test_resolve_variant_defaults_to_tiny_v1_1():
-    assert oe._resolve_variant(None) == "tiny_v1_1"
-    assert oe._resolve_variant({}) == "tiny_v1_1"
+def test_resolve_variant_defaults_to_base_v1_2():
+    assert oe._resolve_variant(None) == "base_v1_2"
+    assert oe._resolve_variant({}) == "base_v1_2"
 
 
 def test_resolve_variant_env_fallback(monkeypatch):
@@ -71,7 +80,7 @@ def test_resolve_variant_model_config_overrides_env(monkeypatch):
 
 def test_resolve_variant_env_auto_gives_default(monkeypatch):
     monkeypatch.setenv("RS_EMBED_OLMOEARTH_VARIANT", "auto")
-    assert oe._resolve_variant(None) == "tiny_v1_1"
+    assert oe._resolve_variant(None) == "base_v1_2"
 
 
 # ---------------------------------------------------------------------------
@@ -1125,9 +1134,9 @@ def test_embedding_meta_has_required_fields(monkeypatch):
     assert meta["model"] == "olmoearth"
     assert meta["type"] == "on_the_fly"
     assert meta["backend"] == "gee"
-    assert meta["variant"] == "tiny_v1_1"
-    assert meta["model_size"] == "tiny"
-    assert meta["model_version"] == "v1.1"
+    assert meta["variant"] == "base_v1_2"
+    assert meta["model_size"] == "base"
+    assert meta["model_version"] == "v1.2"
     assert meta["patch_size"] == oe._DEFAULT_PATCH_SIZE
     assert meta["hf_repo"] is not None
     assert "temporal_range" in meta


### PR DESCRIPTION
## What

Integrate the OlmoEarth **v1.2** model family released on HuggingFace.

Requires `olmoearth-pretrain-minimal>=0.0.6`, which registers the `v1_2` ModelIDs (0.0.5 only knows v1/v1.1 and rejects v1.2 repos).

## Changes

- `_VARIANT_SPECS`: add `nano_v1_2` (128-d), `tiny_v1_2` (192-d), `small_v1_2` (384-d, **new size**), `base_v1_2` (768-d). v1.2 has no `large`.
- Aliases: `nano_12` / `tiny_12` / `small_12` / `base_12`, plus bare `small` (unambiguous — `small` exists only in v1.2).
- **Default variant bumped** `tiny_v1_1` → `base_v1_2` (the v1.2 recommended Base).
- Bump `olmoearth-pretrain-minimal` dependency to `>=0.0.6`.
- Docs (`docs/models/olmoearth.md`) + `describe()`/docstring updated. `model_size` / `model_version` meta derive from `_VARIANT_SPECS`, so they track automatically; embedding width is read from the model output (no per-variant dim wiring).

Depth/embedding-dim are config-driven in the loaded model; the embedder consumes only the final encoder tokens and reads `D` from the output, so new sizes/depths need no code changes.

## Verification

- `api_smoke_all_models --models olmoearth` loads `base_v1_2` end-to-end: `get_embedding` / `get_embeddings_batch` / `export_batch` all OK, 768-d output.
- `tests/test_olmoearth.py`: 107 passed (normalize cases, default-variant, and meta version assertions updated for v1.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)