### PR TITLE
fix: batch 1 pipeline correctness fixes from full-pipeline review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on Keep a Changelog, and the project follows Semantic Versio
 
 ## [Unreleased]
 
+### Fixed
+
+- **Pipeline correctness (review batch 1).** Combined-export `drop_model_arrays` no longer deletes a prefix-sibling model's arrays (`satmae` vs `satmaepp`); per-item exports square-fetch consistently beyond the first chunk (cloned prefetch kept `square_fetch_keys`); the `input_prep="auto"` fallback forwards the ROI crop window instead of silently embedding the enlarged square; base `fetch_input` resolves `temporal=None` to the package default window like every embedder entry point (multi-frame models no longer crash on the default tile path); GEE cloud filtering picks the collection's own property (S2/Landsat) instead of emptying Landsat/S1/DEM collections with the S2-only one, with a unified inclusive threshold; `sensor_cache_key` accepts `cloudy_pct=None`; merged fetch groups no longer share one mutable `fetch_meta` dict across models.
+
 ## [0.2.0] — 2026-06-30
 
 This release adds the OlmoEarth model family, makes the temporal models (`prithvi`, `galileo`, `olmoearth`) sample window-adaptively by default, flips the package-wide default `input_prep` from `resize` to `tile` so all models preserve native resolution by default, and fixes several `export_batch` correctness issues where a point's embedding differed between the single and batch/tiled paths. Some defaults that change embedding behavior are noted below; pin explicit options where strict reproducibility across versions is required.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@ The format is based on Keep a Changelog, and the project follows Semantic Versio
 
 ## [Unreleased]
 
-### Fixed
-
-- **Pipeline correctness (review batch 1).** Combined-export `drop_model_arrays` no longer deletes a prefix-sibling model's arrays (`satmae` vs `satmaepp`); per-item exports square-fetch consistently beyond the first chunk (cloned prefetch kept `square_fetch_keys`); the `input_prep="auto"` fallback forwards the ROI crop window instead of silently embedding the enlarged square; base `fetch_input` resolves `temporal=None` to the package default window like every embedder entry point (multi-frame models no longer crash on the default tile path); GEE cloud filtering picks the collection's own property (S2/Landsat) instead of emptying Landsat/S1/DEM collections with the S2-only one, with a unified inclusive threshold; `sensor_cache_key` accepts `cloudy_pct=None`; merged fetch groups no longer share one mutable `fetch_meta` dict across models.
-
 ## [0.2.0] — 2026-06-30
 
 This release adds the OlmoEarth model family, makes the temporal models (`prithvi`, `galileo`, `olmoearth`) sample window-adaptively by default, flips the package-wide default `input_prep` from `resize` to `tile` so all models preserve native resolution by default, and fixes several `export_batch` correctness issues where a point's embedding differed between the single and batch/tiled paths. Some defaults that change embedding behavior are noted below; pin explicit options where strict reproducibility across versions is required.
@@ -39,6 +35,7 @@ This release adds the OlmoEarth model family, makes the temporal models (`prithv
 
 ### Fixed
 
+- **Pipeline correctness (review batch 1).** Combined-export `drop_model_arrays` no longer deletes a prefix-sibling model's arrays (`satmae` vs `satmaepp`); per-item exports square-fetch consistently beyond the first chunk (cloned prefetch kept `square_fetch_keys`); the `input_prep="auto"` fallback forwards the ROI crop window instead of silently embedding the enlarged square; base `fetch_input` resolves `temporal=None` to the package default window like every embedder entry point (multi-frame models no longer crash on the default tile path); GEE cloud filtering picks the collection's own property (S2/Landsat) instead of emptying Landsat/S1/DEM collections with the S2-only one, with a unified inclusive threshold; `sensor_cache_key` accepts `cloudy_pct=None`; merged fetch groups no longer share one mutable `fetch_meta` dict across models.
 - **Tiled grid embeddings showed a flat "dead band" along a short ROI edge** (most visible on `prithvi` over wide/flat ROIs). The stitcher cropped against the unpadded extent and computed boundary patches over zero-padding; fixes crop against the padded extent, pad edge tiles with edge replication, and let resize-capable models skip padding entirely (short axis fed at native size and resized).
 - **`export_batch` resolved `input_prep` globally instead of per-model, so a point's embedding could differ from `get_embedding`.** The export pipeline now uses `resolve_model_aware_input_prep` so the same point yields identical embeddings via `get_embedding` and `export_batch` (verified across all models × input_prep × output modes).
 - **`remoteclip` produced black-image (garbage) embeddings on every `export_batch` path** due to a double `/10000` normalization in the `input_chw` branches; raw values are now passed through so export embeddings match `get_embedding`, and the provider `value_range` was corrected to `(0, 10000)`.

--- a/src/rs_embed/embedders/base.py
+++ b/src/rs_embed/embedders/base.py
@@ -141,14 +141,14 @@ class EmbedderBase:
             fetch_collection_patch_chw,
             fetch_s2_multiframe_raw_tchw,
         )
+        from .meta import temporal_to_range
+
+        # Embedder entry points resolve temporal via temporal_to_range (None ->
+        # package default window). The prefetch path must fetch the same window,
+        # so normalize here too instead of raising on None / fetching unfiltered.
+        temporal = temporal_to_range(temporal)
 
         if spec.temporal_mode == "multi":
-            if temporal is None:
-                from ..core.errors import ModelError
-
-                raise ModelError(
-                    f"{self.model_name} requires a TemporalSpec for multi-frame fetch."
-                )
             raw = fetch_s2_multiframe_raw_tchw(
                 provider,
                 spatial=spatial,

--- a/src/rs_embed/pipelines/exporter.py
+++ b/src/rs_embed/pipelines/exporter.py
@@ -560,6 +560,7 @@ class BatchExporter:
             inspect_fn=self.inspect_fn,
             fetcher_by_key=src.fetcher_by_key,
         )
+        clone.square_fetch_keys = set(src.square_fetch_keys)
         clone.sensor_by_key = src.sensor_by_key
         clone.fetch_sensor_by_key = src.fetch_sensor_by_key
         clone.sensor_to_fetch = src.sensor_to_fetch

--- a/src/rs_embed/pipelines/prefetch.py
+++ b/src/rs_embed/pipelines/prefetch.py
@@ -245,7 +245,10 @@ class PrefetchManager:
                         self.input_reports[(i, member_skey)] = rep
                     self.cache[(i, member_skey)] = x_member
                     if fmeta:
-                        self.fetch_meta[(i, member_skey)] = fmeta
+                        # Independent copy per member: consumers may mutate the
+                        # dict they receive (or stamp it into Embedding.meta),
+                        # which must not leak into sibling models' crop windows.
+                        self.fetch_meta[(i, member_skey)] = dict(fmeta)
 
                 if fetch_stats is not None:
                     fsensor = self.fetch_sensor_by_key.get(skey)
@@ -322,8 +325,12 @@ class PrefetchManager:
         return x
 
     def get_fetch_meta(self, idx: int, sensor_key: str) -> dict[str, Any]:
-        """Return fetch metadata for a cached input, or empty dict."""
-        return self.fetch_meta.get((idx, sensor_key), {})
+        """Return a copy of the fetch metadata for a cached input, or empty dict.
+
+        A copy so a caller that mutates the returned dict cannot corrupt the
+        cached entry other consumers (retries, sibling models) still read.
+        """
+        return dict(self.fetch_meta.get((idx, sensor_key), {}))
 
     def has_error(self, idx: int, sensor_key: str) -> str | None:
         return self.errors.get((idx, sensor_key))

--- a/src/rs_embed/providers/gee.py
+++ b/src/rs_embed/providers/gee.py
@@ -15,6 +15,7 @@ from .gee_utils import (
     _build_s1_dualpol_collection,
     _collection_size_or_none,
     _fetch_with_bbox_fallback,
+    _filter_clouds,
     _flip_sample_tile_y,
     _format_s1_empty_collection_message,
     _gee_error_message,
@@ -109,11 +110,9 @@ class GEEProvider(ProviderBase):
                 ic = ic.filterBounds(region)
             if temporal_range is not None:
                 ic = ic.filterDate(temporal_range[0], temporal_range[1])
-            if sensor.cloudy_pct is not None:
-                try:
-                    ic = ic.filter(ee.Filter.lte("CLOUDY_PIXEL_PERCENTAGE", int(sensor.cloudy_pct)))
-                except Exception as _e:
-                    pass
+            ic = _filter_clouds(
+                ic, collection=str(sensor.collection), cloudy_pct=sensor.cloudy_pct
+            )
             _raise_if_empty_collection(ic, collection=str(sensor.collection))
 
             if sensor.composite == "median":
@@ -446,11 +445,7 @@ class GEEProvider(ProviderBase):
             .filterDate(temporal.start, temporal.end)
             .filterBounds(region)
         )
-        if cloudy_pct is not None:
-            try:
-                col_all = col_all.filter(ee.Filter.lt("CLOUDY_PIXEL_PERCENTAGE", int(cloudy_pct)))
-            except Exception as _e:
-                pass
+        col_all = _filter_clouds(col_all, collection=str(collection), cloudy_pct=cloudy_pct)
         _raise_if_empty_collection(col_all, collection=str(collection))
 
         comp = str(composite).lower().strip()

--- a/src/rs_embed/providers/gee.py
+++ b/src/rs_embed/providers/gee.py
@@ -110,9 +110,7 @@ class GEEProvider(ProviderBase):
                 ic = ic.filterBounds(region)
             if temporal_range is not None:
                 ic = ic.filterDate(temporal_range[0], temporal_range[1])
-            ic = _filter_clouds(
-                ic, collection=str(sensor.collection), cloudy_pct=sensor.cloudy_pct
-            )
+            ic = _filter_clouds(ic, collection=str(sensor.collection), cloudy_pct=sensor.cloudy_pct)
             _raise_if_empty_collection(ic, collection=str(sensor.collection))
 
             if sensor.composite == "median":

--- a/src/rs_embed/providers/gee_utils.py
+++ b/src/rs_embed/providers/gee_utils.py
@@ -288,6 +288,41 @@ def _resolve_band_aliases(collection: str, bands: tuple[str, ...]) -> tuple[str,
     return tuple(amap.get((b or "").upper(), b) for b in bands)
 
 
+# ── Cloud-cover filtering ─────────────────────────────────────────────────────
+
+# Scene-level cloud-cover property per collection family. GEE property filters
+# EXCLUDE images that lack the property, so applying the S2 property to any
+# other collection silently filters out every image.
+_CLOUD_PROPERTY_BY_COLLECTION: tuple[tuple[str, str], ...] = (
+    ("COPERNICUS/S2", "CLOUDY_PIXEL_PERCENTAGE"),
+    ("LANDSAT/", "CLOUD_COVER"),
+)
+
+
+def _cloud_property_for_collection(collection: str) -> str | None:
+    c = (collection or "").upper()
+    for marker, prop in _CLOUD_PROPERTY_BY_COLLECTION:
+        if marker in c:
+            return prop
+    return None
+
+
+def _filter_clouds(col: Any, *, collection: str, cloudy_pct: int | None) -> Any:
+    """Apply the collection's scene cloud-cover filter (inclusive threshold).
+
+    Collections without a known cloud-cover property (SAR, DEMs, ...) are
+    returned unfiltered rather than emptied by a filter on a missing property.
+    """
+    if cloudy_pct is None:
+        return col
+    prop = _cloud_property_for_collection(collection)
+    if prop is None:
+        return col
+    import ee
+
+    return col.filter(ee.Filter.lte(prop, int(cloudy_pct)))
+
+
 # ── Temporal split helper ─────────────────────────────────────────────────────
 
 

--- a/src/rs_embed/tools/checkpoint_utils.py
+++ b/src/rs_embed/tools/checkpoint_utils.py
@@ -124,12 +124,15 @@ def restore_prefetch_checkpoint_cache(
 
 def drop_model_arrays(arrays: dict[str, np.ndarray], model_name: str, *, sanitize_key) -> None:
     mkey = sanitize_key(model_name)
-    prefixes = (
+    # Keys are either exact ("embeddings__<m>") or ragged per-item
+    # ("embedding__<m>__00042"). Match on the "__" boundary so one model name
+    # that prefixes another (satmae / satmaepp) never drops the other's arrays.
+    bases = (
         f"embeddings__{mkey}",
         f"embedding__{mkey}",
         f"inputs_bchw__{mkey}",
         f"input_chw__{mkey}",
     )
     for key in list(arrays.keys()):
-        if key.startswith(prefixes):
+        if any(key == base or key.startswith(base + "__") for base in bases):
             arrays.pop(key, None)

--- a/src/rs_embed/tools/serialization.py
+++ b/src/rs_embed/tools/serialization.py
@@ -88,7 +88,7 @@ def sensor_cache_key(sensor: SensorSpec) -> str:
         "collection": sensor.collection,
         "bands": list(sensor.bands),
         "scale_m": int(sensor.scale_m),
-        "cloudy_pct": int(sensor.cloudy_pct),
+        "cloudy_pct": int(sensor.cloudy_pct) if sensor.cloudy_pct is not None else None,
         "fill_value": float(sensor.fill_value),
         "composite": str(sensor.composite),
         "modality": getattr(sensor, "modality", None),

--- a/src/rs_embed/tools/tiling.py
+++ b/src/rs_embed/tools/tiling.py
@@ -850,6 +850,7 @@ def _call_embedder_get_embedding_tiled(
                 backend=backend,
                 device=device,
                 input_chw=x,
+                fetch_meta=fetch_meta,
             )
     elif input_prep.mode == "tile":
         if num_tiles > input_prep.max_tiles_hard:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -554,6 +554,16 @@ def test_sensor_cache_key_deterministic_and_differs():
     assert _sensor_cache_key(s1) != _sensor_cache_key(s2)
 
 
+def test_sensor_cache_key_accepts_none_cloudy_pct():
+    """cloudy_pct=None is a legitimate sensor config (no cloud filter) and
+    must key like any other value instead of crashing export planning."""
+    s_none = SensorSpec(collection="A", bands=("B1",), cloudy_pct=None)  # type: ignore[arg-type]
+    s_30 = SensorSpec(collection="A", bands=("B1",), cloudy_pct=30)
+    assert isinstance(_sensor_cache_key(s_none), str)
+    assert _sensor_cache_key(s_none) == _sensor_cache_key(s_none)
+    assert _sensor_cache_key(s_none) != _sensor_cache_key(s_30)
+
+
 # ══════════════════════════════════════════════════════════════════════
 # export_batch — argument validation (no GEE needed)
 # ══════════════════════════════════════════════════════════════════════

--- a/tests/test_checkpoint_utils.py
+++ b/tests/test_checkpoint_utils.py
@@ -1,0 +1,37 @@
+"""Tests for rs_embed.tools.checkpoint_utils helpers."""
+
+import numpy as np
+
+from rs_embed.tools.checkpoint_utils import drop_model_arrays
+
+
+def _sanitize(s: str) -> str:
+    return s.replace("/", "_").replace(" ", "_")
+
+
+def test_drop_model_arrays_removes_exact_and_ragged_keys():
+    arrays = {
+        "embeddings__satmae": np.zeros(2),
+        "embedding__satmae__00003": np.zeros(2),
+        "inputs_bchw__satmae": np.zeros(2),
+        "input_chw__satmae__00003": np.zeros(2),
+        "other": np.zeros(2),
+    }
+    drop_model_arrays(arrays, "satmae", sanitize_key=_sanitize)
+    assert set(arrays) == {"other"}
+
+
+def test_drop_model_arrays_does_not_drop_prefix_sibling_model():
+    """satmae must not delete satmaepp's arrays (prefix collision)."""
+    arrays = {
+        "embeddings__satmae": np.zeros(2),
+        "embeddings__satmaepp": np.ones(2),
+        "inputs_bchw__satmaepp": np.ones(2),
+        "embedding__satmaepp__00001": np.ones(2),
+    }
+    drop_model_arrays(arrays, "satmae", sanitize_key=_sanitize)
+    assert set(arrays) == {
+        "embeddings__satmaepp",
+        "inputs_bchw__satmaepp",
+        "embedding__satmaepp__00001",
+    }

--- a/tests/test_embedder_base_contracts.py
+++ b/tests/test_embedder_base_contracts.py
@@ -273,3 +273,80 @@ def test_onthefly_embedders_that_accept_input_chw_implement_batch_from_inputs():
         "remove from _KNOWN_MISSING_BATCH_FROM_INPUTS if present):\n  "
         + "\n  ".join(sorted(missing_override))
     )
+
+
+def test_base_fetch_input_multi_defaults_temporal_like_get_embedding(monkeypatch):
+    """fetch_input(temporal=None) must use the temporal_to_range default window.
+
+    Regression: multi-frame spec models without a fetch_input override
+    (anysat, agrifm) raised on temporal=None from the API prefetch path,
+    while the same call with input_prep='resize' succeeded via the
+    embedder's own temporal_to_range default.
+    """
+    import numpy as np
+
+    from rs_embed.core.specs import ModelInputSpec, PointBuffer
+    from rs_embed.embedders.base import EmbedderBase
+    from rs_embed.embedders.meta import temporal_to_range
+
+    seen: dict[str, object] = {}
+
+    def fake_multi(provider, *, spatial, temporal, **kwargs):
+        seen["temporal"] = temporal
+        return np.zeros((2, 1, 4, 4), dtype=np.float32)
+
+    monkeypatch.setattr("rs_embed.providers.fetch.fetch_s2_multiframe_raw_tchw", fake_multi)
+
+    class _MultiModel(EmbedderBase):
+        model_name = "multi_dummy"
+        input_spec = ModelInputSpec(
+            collection="C",
+            bands=("B1",),
+            temporal_mode="multi",
+            n_frames=2,
+        )
+
+    fr = _MultiModel().fetch_input(
+        object(),
+        spatial=PointBuffer(lon=0.0, lat=0.0, buffer_m=10),
+        temporal=None,
+        sensor=None,
+    )
+    assert fr is not None
+    default = temporal_to_range(None)
+    assert seen["temporal"] == default
+
+
+def test_base_fetch_input_single_defaults_temporal_like_get_embedding(monkeypatch):
+    """Single-composite fetch_input(temporal=None) must not fetch unfiltered.
+
+    The direct get_embedding path resolves None to the package default
+    window; the prefetch path previously passed None through to the
+    provider (whole-collection composite, different data).
+    """
+    import numpy as np
+
+    from rs_embed.core.specs import ModelInputSpec, PointBuffer
+    from rs_embed.embedders.base import EmbedderBase
+    from rs_embed.embedders.meta import temporal_to_range
+
+    seen: dict[str, object] = {}
+
+    def fake_single(provider, *, spatial, temporal, **kwargs):
+        seen["temporal"] = temporal
+        return np.zeros((1, 4, 4), dtype=np.float32)
+
+    monkeypatch.setattr("rs_embed.providers.fetch.fetch_collection_patch_chw", fake_single)
+
+    class _SingleModel(EmbedderBase):
+        model_name = "single_dummy"
+        input_spec = ModelInputSpec(collection="C", bands=("B1",))
+
+    fr = _SingleModel().fetch_input(
+        object(),
+        spatial=PointBuffer(lon=0.0, lat=0.0, buffer_m=10),
+        temporal=None,
+        sensor=None,
+    )
+    assert fr is not None
+    assert seen["temporal"] == temporal_to_range(None)

--- a/tests/test_export_roi_crop.py
+++ b/tests/test_export_roi_crop.py
@@ -441,3 +441,81 @@ def test_run_batch_tiled_single_tile_keeps_roi_meta():
     assert succeeded
     assert out[0].status.value == "ok"
     assert emb.seen_fetch_metas == [{"roi_window_geo": _ROI}]
+
+
+def test_per_item_pipelined_chunks_keep_square_fetch(tmp_path, monkeypatch):
+    """Chunks beyond the first must square-fetch exactly like chunk 1.
+
+    Regression: the pipelined per-item path clones the PrefetchManager for
+    every chunk after the first, and the clone dropped ``square_fetch_keys``
+    (it is injected post-construction by the exporter). Points 2+ were then
+    fetched as raw rectangles with no ``roi_window_geo`` — silently diverging
+    from chunk 1 and from get_embedding.
+    """
+    fetched_spatials: list = []
+    seen_fetch_meta: list = []
+
+    class DummyGenericFetch:
+        def describe(self):
+            return dict(_DESCRIBE)
+
+        def get_embedding(
+            self,
+            *,
+            spatial,
+            temporal,
+            sensor,
+            output,
+            backend,
+            device="auto",
+            input_chw=None,
+            fetch_meta=None,
+        ):
+            _ = spatial, temporal, sensor, output, backend, device
+            assert input_chw is not None
+            seen_fetch_meta.append(dict(fetch_meta) if fetch_meta else None)
+            return Embedding(data=np.array([1.0], dtype=np.float32), meta={})
+
+    registry.register("dummy_generic_fetch")(DummyGenericFetch)
+
+    import rs_embed.api as api
+
+    def fake_fetch(provider, *, spatial, temporal, sensor):
+        _ = provider, temporal, sensor
+        fetched_spatials.append(spatial)
+        return np.full((1, 4, 4), 0.5, dtype=np.float32)
+
+    _patch_provider(monkeypatch)
+    monkeypatch.setattr("rs_embed.providers.fetch.fetch_sensor_patch_chw", fake_fetch)
+
+    rects = [
+        BBox(minlon=0.0, minlat=0.0, maxlon=0.2, maxlat=0.05),
+        BBox(minlon=1.0, minlat=1.0, maxlon=1.2, maxlat=1.05),
+        BBox(minlon=2.0, minlat=2.0, maxlon=2.2, maxlat=2.05),
+    ]
+    out_dir = tmp_path / "per_item_sq"
+    manifests = api.export_batch(
+        spatials=rects,
+        temporal=TemporalSpec.range("2020-01-01", "2020-02-01"),
+        models=["dummy_generic_fetch"],
+        target=ExportTarget.per_item(str(out_dir)),
+        config=ExportConfig(
+            save_inputs=False,
+            save_embeddings=True,
+            show_progress=False,
+            chunk_size=1,  # 3 points -> 3 chunks -> chunks 2-3 use _clone_prefetch
+        ),
+        backend="gee",
+        device="cpu",
+        output=OutputSpec.pooled(),
+    )
+
+    assert [m.get("status") for m in manifests] == ["ok", "ok", "ok"]
+    assert len(fetched_spatials) == 3
+    for i, sq in enumerate(fetched_spatials):
+        w = float(sq.maxlon) - float(sq.minlon)
+        h = float(sq.maxlat) - float(sq.minlat)
+        assert abs(w - h) / max(w, h) < 0.15, f"fetch {i} was not squared"
+    assert len(seen_fetch_meta) == 3
+    for i, fm in enumerate(seen_fetch_meta):
+        assert fm is not None and "roi_window_geo" in fm, f"point {i} lost roi_window_geo"

--- a/tests/test_fetch_stats.py
+++ b/tests/test_fetch_stats.py
@@ -684,3 +684,45 @@ def test_export_batch_fetch_stats_last_point_and_sensor_in_log(tmp_path, monkeyp
     captured = capsys.readouterr()
     assert "last=point:" in captured.err
     assert "sensor:" in captured.err
+
+
+def test_fetch_meta_independent_per_member_and_copied_on_read():
+    """Members of a merged fetch group must not share one fetch_meta object.
+
+    Regression: the same fmeta dict was stored under every member key and
+    returned uncopied by get_fetch_meta; a consumer that mutated it (e.g.
+    popping roi_window_geo) corrupted sibling models' crop windows.
+    """
+    from rs_embed.core.specs import BBox
+    from rs_embed.pipelines.prefetch import PrefetchManager
+
+    sensor1 = SensorSpec(collection="C", bands=("B1",))
+    sensor2 = SensorSpec(collection="C", bands=("B2",))
+    cfg = ExportConfig(save_inputs=True, save_embeddings=True)
+    pm = PrefetchManager(
+        provider=object(),
+        models=["m1", "m2"],
+        resolved_sensor={"m1": sensor1, "m2": sensor2},
+        model_type={"m1": "onthefly", "m2": "onthefly"},
+        config=cfg,
+        fetch_fn=lambda *a, **kw: np.ones((2, 4, 4), dtype=np.float32),
+        inspect_fn=lambda *a, **kw: {"ok": True},
+    )
+    pm.plan()
+    assert len(pm.fetch_sensor_by_key) == 1  # one merged band-union fetch
+    pm.square_fetch_keys = set(pm.fetch_sensor_by_key)
+
+    rect = BBox(minlon=0.0, minlat=0.0, maxlon=0.2, maxlat=0.05)
+    pm.fetch_chunk([0], [rect], TemporalSpec.year(2022))
+
+    member_keys = sorted(k for k in pm.fetch_meta if k[0] == 0)
+    assert len(member_keys) == 2
+    meta_a = pm.fetch_meta[member_keys[0]]
+    meta_b = pm.fetch_meta[member_keys[1]]
+    assert meta_a == meta_b and "roi_window_geo" in meta_a
+    assert meta_a is not meta_b
+
+    # Mutating what a consumer got back must not corrupt the cached entry.
+    got = pm.get_fetch_meta(*member_keys[0])
+    got.pop("roi_window_geo", None)
+    assert "roi_window_geo" in pm.get_fetch_meta(*member_keys[0])

--- a/tests/test_gee_provider.py
+++ b/tests/test_gee_provider.py
@@ -767,8 +767,7 @@ def test_cloud_property_for_collection_mapping():
     from rs_embed.providers.gee_utils import _cloud_property_for_collection
 
     assert (
-        _cloud_property_for_collection("COPERNICUS/S2_SR_HARMONIZED")
-        == "CLOUDY_PIXEL_PERCENTAGE"
+        _cloud_property_for_collection("COPERNICUS/S2_SR_HARMONIZED") == "CLOUDY_PIXEL_PERCENTAGE"
     )
     assert _cloud_property_for_collection("LANDSAT/LC08/C02/T1_L2") == "CLOUD_COVER"
     assert _cloud_property_for_collection("LANDSAT/LE07/C02/T1_L2") == "CLOUD_COVER"

--- a/tests/test_gee_provider.py
+++ b/tests/test_gee_provider.py
@@ -761,3 +761,110 @@ def test_fetch_all_bands_impl_passes_through_gee_row_order(monkeypatch):
     # Empirically GEE returns north-up for this call pattern, so row 0 = northernmost.
     np.testing.assert_allclose(arr[0, 0], _NORTH_ROW)
     np.testing.assert_allclose(arr[0, 1], _SOUTH_ROW)
+
+
+def test_cloud_property_for_collection_mapping():
+    from rs_embed.providers.gee_utils import _cloud_property_for_collection
+
+    assert (
+        _cloud_property_for_collection("COPERNICUS/S2_SR_HARMONIZED")
+        == "CLOUDY_PIXEL_PERCENTAGE"
+    )
+    assert _cloud_property_for_collection("LANDSAT/LC08/C02/T1_L2") == "CLOUD_COVER"
+    assert _cloud_property_for_collection("LANDSAT/LE07/C02/T1_L2") == "CLOUD_COVER"
+    assert _cloud_property_for_collection("COPERNICUS/S1_GRD") is None
+    assert _cloud_property_for_collection("USGS/SRTMGL1_003") is None
+    assert _cloud_property_for_collection("") is None
+
+
+def test_filter_clouds_uses_collection_property_and_skips_unknown(monkeypatch):
+    """Cloud filtering must use the collection's own property (inclusive lte)
+    and must not empty collections that lack a cloud-cover property.
+
+    Regression: the S2-only CLOUDY_PIXEL_PERCENTAGE filter was applied
+    unconditionally with the default cloudy_pct=30; GEE property filters
+    exclude images lacking the property, so every Landsat/S1/DEM request
+    dropped all images and failed with a misleading 'No images found'.
+    """
+    import sys
+    import types
+
+    from rs_embed.providers.gee_utils import _filter_clouds
+
+    seen_filters = []
+
+    class _FakeCollection:
+        def filter(self, f):
+            seen_filters.append(f)
+            return self
+
+    fake_ee = types.SimpleNamespace(
+        Filter=types.SimpleNamespace(lte=lambda prop, val: ("lte", prop, val))
+    )
+    monkeypatch.setitem(sys.modules, "ee", fake_ee)
+
+    col = _FakeCollection()
+
+    # S2 -> its own property, inclusive threshold.
+    out = _filter_clouds(col, collection="COPERNICUS/S2_SR_HARMONIZED", cloudy_pct=30)
+    assert out is col
+    assert seen_filters == [("lte", "CLOUDY_PIXEL_PERCENTAGE", 30)]
+
+    # Landsat -> CLOUD_COVER, not the S2 property.
+    seen_filters.clear()
+    _filter_clouds(col, collection="LANDSAT/LC08/C02/T1_L2", cloudy_pct=20)
+    assert seen_filters == [("lte", "CLOUD_COVER", 20)]
+
+    # No cloud property (SAR/DEM) -> unfiltered.
+    seen_filters.clear()
+    out = _filter_clouds(col, collection="COPERNICUS/S1_GRD", cloudy_pct=30)
+    assert out is col
+    assert seen_filters == []
+
+    # cloudy_pct=None -> unfiltered.
+    _filter_clouds(col, collection="COPERNICUS/S2_SR_HARMONIZED", cloudy_pct=None)
+    assert seen_filters == []
+
+
+def test_build_image_default_cloudy_pct_does_not_empty_landsat(monkeypatch):
+    """A default-constructed SensorSpec (cloudy_pct=30) for Landsat must
+    filter on CLOUD_COVER, not filter out every image via the S2 property."""
+    import sys
+    import types
+
+    seen_filters = []
+
+    class _FakeSize:
+        def getInfo(self):
+            return 3
+
+    class _FakeCollection:
+        def filterBounds(self, _region):
+            return self
+
+        def filterDate(self, _start, _end):
+            return self
+
+        def filter(self, f):
+            seen_filters.append(f)
+            return self
+
+        def size(self):
+            return _FakeSize()
+
+        def median(self):
+            return "median_image"
+
+    fake_ee = types.SimpleNamespace(
+        ImageCollection=lambda _collection: _FakeCollection(),
+        Filter=types.SimpleNamespace(lte=lambda prop, val: ("lte", prop, val)),
+    )
+    monkeypatch.setitem(sys.modules, "ee", fake_ee)
+
+    provider = GEEProvider(auto_auth=False)
+    sensor = SensorSpec(collection="LANDSAT/LC08/C02/T1_L2", bands=("SR_B4",))
+    temporal = TemporalSpec.range("2024-01-01", "2024-02-01")
+
+    img = provider.build_image(sensor=sensor, temporal=temporal, region=object())
+    assert img == "median_image"
+    assert seen_filters == [("lte", "CLOUD_COVER", 30)]

--- a/tests/test_input_prep_tiling.py
+++ b/tests/test_input_prep_tiling.py
@@ -878,3 +878,67 @@ def test_batch_tiled_path_matches_single_snap_and_meta():
     # Parity: the two paths stamp an identical input_prep block (jsonable() has
     # already turned the batch path's tuples into lists, so normalize both).
     assert jsonable(single_prep) == batch_prep
+
+
+class _FakeMetaEmbedder:
+    """Records the fetch_meta each get_embedding call receives."""
+
+    model_name = "fake_meta"
+
+    def __init__(self):
+        self.seen_fetch_meta = []
+
+    def describe(self):
+        return {"defaults": {"image_size": 4}}
+
+    def get_embedding(
+        self,
+        *,
+        spatial,
+        temporal=None,
+        sensor=None,
+        output=OutputSpec.pooled(),
+        backend="gee",
+        device="cpu",
+        input_chw=None,
+        fetch_meta=None,
+    ):
+        self.seen_fetch_meta.append(dict(fetch_meta) if fetch_meta else None)
+        x = np.asarray(input_chw, dtype=np.float32)
+        return Embedding(data=np.asarray([float(x.mean())], dtype=np.float32), meta={})
+
+
+@pytest.mark.parametrize(
+    "output,input_hw",
+    [
+        (OutputSpec.pooled(), (8, 8)),  # auto + pooled always falls back
+        (OutputSpec.grid(), (4, 4)),  # auto + grid, single tile -> fallback
+    ],
+)
+def test_auto_mode_fallback_forwards_fetch_meta(output, input_hw):
+    """The auto-mode fallback must not drop the fetch-square crop window.
+
+    Regression: the auto fallback branch called the embedder without
+    fetch_meta, so a rectangular ROI prefetched as an enlarged square was
+    never cropped back - the pooled embedding silently covered imagery
+    outside the requested bbox.
+    """
+    emb = _FakeMetaEmbedder()
+    h, w = input_hw
+    x = np.zeros((1, h, w), dtype=np.float32)
+    roi = {"roi_window_geo": (0.25, 0.75, 0.0, 1.0)}
+
+    _call_embedder_get_embedding_with_input_prep(
+        embedder=emb,
+        spatial=_bbox(),
+        temporal=None,
+        sensor=None,
+        output=output,
+        backend="gee",
+        device="cpu",
+        input_chw=x,
+        input_prep=InputPrepSpec.auto(tile_size=4),
+        fetch_meta=dict(roi),
+    )
+
+    assert emb.seen_fetch_meta == [roi]


### PR DESCRIPTION
## Summary

First batch of fixes from a full review of the data-fetch → input-prep → inference → export pipeline. All seven are small, localized fixes for confirmed silent-wrong-data or crash bugs; each comes with a regression test verified to fail without the fix. Full suite: **907 passed, 2 skipped**.

### Fixes

1. **`drop_model_arrays` prefix collision silently deleted a sibling model's data** (`tools/checkpoint_utils.py`)
   `key.startswith(prefixes)` had no boundary, so dropping `satmae` also deleted `embeddings__satmaepp` from a combined export while the manifest still reported it as `ok`. Keys now match exactly or on the `__` ragged-suffix boundary.

2. **`_clone_prefetch` dropped `square_fetch_keys`** (`pipelines/exporter.py`)
   The pipelined per-item path clones the PrefetchManager for every chunk after the first, but `square_fetch_keys` is injected post-construction and was not copied. Points beyond the first chunk were fetched as raw rectangles with no `roi_window_geo` — silently diverging from chunk 1 and from `get_embedding`.

3. **Auto-mode tiling fallback dropped `fetch_meta`** (`tools/tiling.py`)
   The `auto` fallback branch called the embedder without `fetch_meta` (the other two fallbacks forward it), so a rectangular ROI prefetched as an enlarged square was never cropped back — auto+pooled embeddings silently covered imagery outside the requested bbox.

4. **Base `fetch_input` diverged from the embedder temporal convention** (`embedders/base.py`)
   Embedder entry points resolve `temporal=None` to the package default window via `temporal_to_range`, but the base `fetch_input` raised on `None` for multi-frame specs (anysat/agrifm failed on the default tile prep path while `input_prep=\"resize\"` succeeded) and passed `None` through unfiltered for single-composite specs (prefetch fetched a whole-collection composite while the direct path fetched the default window). Both modes now normalize once at the top of `fetch_input`.

5. **Cloud filter applied the S2-only property to every collection** (`providers/gee.py`, `providers/gee_utils.py`)
   `CLOUDY_PIXEL_PERCENTAGE` was filtered unconditionally whenever `cloudy_pct` was set (default 30). GEE property filters exclude images lacking the property, so Landsat/S1/DEM requests dropped all images and failed with a misleading \"No images found\". A new `_filter_clouds` helper maps S2 → `CLOUDY_PIXEL_PERCENTAGE`, Landsat → `CLOUD_COVER`, and skips collections with no cloud property. Also unifies the single-composite (`lte`) vs multiframe (`lt`) threshold on inclusive `lte` and removes the dead `try/except` around the lazy filter.

6. **`sensor_cache_key` crashed on `cloudy_pct=None`** (`tools/serialization.py`)
   `int(None)` raised `TypeError` for a legitimate no-cloud-filter sensor config that `prefetch_plan` and the fetch helpers already support, crashing export planning.

7. **One `fetch_meta` dict shared across fetch-group members** (`pipelines/prefetch.py`)
   `fetch_chunk` stored the same `fmeta` object under every member key of a merged band-union fetch, and `get_fetch_meta` returned it uncopied — a consumer mutating the dict it received (or stamping it into `Embedding.meta`) corrupted sibling models' `roi_window_geo` crop windows. Each member now gets an independent copy, and reads return a copy.

### Test notes

- Every fix has a dedicated regression test; each was verified red before the fix and green after.
- New test files: `tests/test_checkpoint_utils.py`; new cases in `test_export_roi_crop.py`, `test_input_prep_tiling.py`, `test_embedder_base_contracts.py`, `test_gee_provider.py`, `test_api.py`, `test_fetch_stats.py`.

### Behavior changes to be aware of

- Multiframe cloud threshold changed from exclusive `lt` to inclusive `lte` (now consistent with the single-composite path): scenes at exactly `cloudy_pct` are now included.
- `fetch_input(temporal=None)` on the prefetch path now fetches the package default window instead of an unfiltered whole-collection composite (single mode) or raising (multi mode) — this makes the prefetch path match what the direct `get_embedding` path already did.

This is batch 1 of a planned series; follow-ups (resume request fingerprinting + atomic writes, provider correctness, tiling math, embedder contracts) are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)