### PR TITLE
refactor: remove dead sensor_k plumbing; single source for sensor identity keys (H4)

### DIFF
--- a/src/rs_embed/model.py
+++ b/src/rs_embed/model.py
@@ -37,7 +37,6 @@ from .tools.runtime import (
     require_model_config_support,
     resolve_model_aware_input_prep,
     run_embedding_request,
-    sensor_key,
 )
 
 
@@ -125,9 +124,8 @@ class Model:
         if self._input_prep_resolved.mode == "tile" and self._sensor is None:
             self._sensor = default_sensor_for_model(self._model_n)
 
-        sensor_k = sensor_key(self._sensor)
         self._embedder, self._lock = get_embedder_bundle_cached(
-            self._model_n, self._backend_n, self._device, sensor_k
+            self._model_n, self._backend_n, self._device
         )
         require_model_config_support(
             embedder=self._embedder,

--- a/src/rs_embed/pipelines/combined_flow.py
+++ b/src/rs_embed/pipelines/combined_flow.py
@@ -19,7 +19,6 @@ from ..tools.normalization import normalize_model_name
 from ..tools.progress import create_progress
 from ..tools.runtime import (
     get_embedder_bundle_cached,
-    sensor_key,
 )
 from ..tools.serialization import (
     jsonable,
@@ -115,10 +114,7 @@ def run_pending_models(
             is_precomputed = "precomputed" in (model_type.get(m) or "")
 
             # Resolve embedder just for describe()
-            sensor_k = sensor_key(sspec)
-            embedder, _lock = get_embedder_bundle_cached(
-                normalize_model_name(m), m_backend, device, sensor_k
-            )
+            embedder, _lock = get_embedder_bundle_cached(normalize_model_name(m), m_backend, device)
             try:
                 m_entry["describe"] = jsonable(embedder.describe())
             except Exception as e:

--- a/src/rs_embed/pipelines/inference.py
+++ b/src/rs_embed/pipelines/inference.py
@@ -23,7 +23,6 @@ from ..tools.runtime import (
     get_embedder_bundle_cached,
     require_model_config_support,
     resolve_model_aware_input_prep,
-    sensor_key,
     supports_batch_api,
     supports_prefetched_batch_api,
 )
@@ -58,7 +57,6 @@ class _ModelContext(NamedTuple):
 
     embedder: Any
     lock: Any
-    sensor_k: str
     skey: str | None
     needs_provider_input: bool
 
@@ -183,19 +181,17 @@ class InferenceEngine:
         """Resolve embedder bundle and provider-input requirements for one model."""
         from ..tools.normalization import normalize_model_name
 
-        sensor_k = sensor_key(sensor)
         skey = (
             sensor_cache_key(sensor)
             if provider_enabled and sensor is not None and not is_precomputed
             else None
         )
         embedder, lock = get_embedder_bundle_cached(
-            normalize_model_name(name), backend, self.device, sensor_k
+            normalize_model_name(name), backend, self.device
         )
         return _ModelContext(
             embedder=embedder,
             lock=lock,
-            sensor_k=sensor_k,
             skey=skey,
             needs_provider_input=(skey is not None),
         )
@@ -823,12 +819,10 @@ class InferenceEngine:
         """Return ``(embedder, lock)`` for the given model config."""
         from ..tools.normalization import normalize_model_name
 
-        sensor_k = sensor_key(model_config.sensor)
         return get_embedder_bundle_cached(
             normalize_model_name(model_config.name),
             model_config.backend,
             device,
-            sensor_k,
         )
 
     # ── combined-export: infer all spatials for one model ──────────

--- a/src/rs_embed/pipelines/point_payload.py
+++ b/src/rs_embed/pipelines/point_payload.py
@@ -22,7 +22,6 @@ from ..tools.runtime import (
     get_embedder_bundle_cached,
     resolve_model_aware_input_prep,
     run_with_retry,
-    sensor_key,
 )
 from ..tools.serialization import (
     embedding_to_numpy,
@@ -125,12 +124,9 @@ def build_one_point_payload(
         m_entry["sensor"] = jsonable(sspec)
 
         try:
-            sensor_k = sensor_key(sspec)
             m_backend = _resolved_backend.get(m, backend)
             model_config = resolved_model_config.get(m)
-            embedder, lock = get_embedder_bundle_cached(
-                normalize_model_name(m), m_backend, device, sensor_k
-            )
+            embedder, lock = get_embedder_bundle_cached(normalize_model_name(m), m_backend, device)
 
             try:
                 m_entry["describe"] = jsonable(embedder.describe())

--- a/src/rs_embed/pipelines/prefetch.py
+++ b/src/rs_embed/pipelines/prefetch.py
@@ -159,7 +159,6 @@ class PrefetchManager:
             _embedder_method_accepts_parameter,
             _overrides_base_method,
             get_embedder_bundle_cached,
-            sensor_key,
         )
         from ..tools.serialization import sensor_cache_key
 
@@ -179,7 +178,6 @@ class PrefetchManager:
                 normalize_model_name(mc.name),
                 self.resolved_backend.get(mc.name, self.backend),
                 self.device,
-                sensor_key(mc.sensor),
             )
             meta_safe_by_key[fetch_key] = meta_safe_by_key.get(
                 fetch_key, True

--- a/src/rs_embed/providers/prefetch_plan.py
+++ b/src/rs_embed/providers/prefetch_plan.py
@@ -7,27 +7,18 @@ import numpy as np
 
 from ..core.specs import SensorSpec
 from ..tools.serialization import sensor_cache_key as _sensor_cache_key
+from ..tools.serialization import sensor_identity_fields as _sensor_identity_fields
 
 _LEGACY_RESOLVE_BANDS_WARNED = False
 
 
-def sensor_fetch_group_key(
-    sensor: SensorSpec,
-) -> tuple[str, int, int, float, str, str | None, str | None, bool, bool, bool]:
-    """Fetch identity excluding bands; used to build reusable band supersets."""
-    cloudy = -1 if getattr(sensor, "cloudy_pct", None) is None else int(sensor.cloudy_pct)
-    return (
-        str(sensor.collection),
-        int(sensor.scale_m),
-        cloudy,
-        float(sensor.fill_value),
-        str(sensor.composite),
-        getattr(sensor, "modality", None),
-        getattr(sensor, "orbit", None),
-        bool(getattr(sensor, "use_float_linear", True)),
-        bool(getattr(sensor, "s1_require_iw", True)),
-        bool(getattr(sensor, "s1_relax_iw_on_empty", True)),
-    )
+def sensor_fetch_group_key(sensor: SensorSpec) -> tuple:
+    """Fetch identity excluding bands; used to build reusable band supersets.
+
+    Derived from :func:`~rs_embed.tools.serialization.sensor_identity_fields`
+    so the field set stays in lockstep with :func:`sensor_cache_key`.
+    """
+    return tuple(sorted(_sensor_identity_fields(sensor, include_bands=False).items()))
 
 
 def select_prefetched_channels(x_chw: np.ndarray, idx: tuple[int, ...]) -> np.ndarray:

--- a/src/rs_embed/tools/runtime.py
+++ b/src/rs_embed/tools/runtime.py
@@ -175,27 +175,17 @@ def describe_model_cached(model_n: str) -> dict[str, Any]:
 
 
 @lru_cache(maxsize=32)
-def _embedder_bundle_cached(model: str, backend: str, device: str):
-    cls = get_embedder_cls(model)
-    return cls(), RLock()
-
-
-def get_embedder_bundle_cached(model: str, backend: str, device: str, sensor_k: tuple = ()):
+def get_embedder_bundle_cached(model: str, backend: str, device: str):
     """Return (embedder instance, instance lock).
 
-    Instances are constructed bare — no sensor state — so the cache is keyed
-    by (model, backend, device) only. ``sensor_k`` is accepted for
-    call-site compatibility but ignored: keying on it multiplied embedder
-    instances (each holding its own lazily-loaded state) per sensor variation,
-    including fields like check_save_dir that cannot affect the instance.
+    Instances are constructed bare — no sensor state — so the cache keys on
+    (model, backend, device) only.  Sensor identity is deliberately excluded:
+    keying on it multiplied embedder instances (each holding its own
+    lazily-loaded state) per sensor variation, including fields like
+    check_save_dir that cannot affect the instance.
     """
-    _ = sensor_k
-    return _embedder_bundle_cached(str(model), str(backend), str(device))
-
-
-# Preserve the lru_cache management surface on the public wrapper.
-get_embedder_bundle_cached.cache_clear = _embedder_bundle_cached.cache_clear  # type: ignore[attr-defined]
-get_embedder_bundle_cached.cache_info = _embedder_bundle_cached.cache_info  # type: ignore[attr-defined]
+    cls = get_embedder_cls(model)
+    return cls(), RLock()
 
 
 def _clear_loaded_embedder_module_caches() -> int:
@@ -247,39 +237,6 @@ def reset_runtime() -> dict[str, int]:
         "runtime_caches_cleared": len(runtime_caches),
         "embedder_module_caches_cleared": int(embedder_module_caches_cleared),
     }
-
-
-def sensor_key(sensor: SensorSpec | None) -> tuple:
-    """Build a hashable cache key from a :class:`SensorSpec`.
-
-    Parameters
-    ----------
-    sensor : SensorSpec or None
-        Sensor to hash. Returns a sentinel tuple when ``None``.
-
-    Returns
-    -------
-    tuple
-        Hashable key representing all sensor fields relevant to caching.
-    """
-    if sensor is None:
-        return ("__none__",)
-    return (
-        sensor.collection,
-        sensor.bands,
-        sensor.scale_m,
-        sensor.cloudy_pct,
-        float(sensor.fill_value),
-        str(sensor.composite),
-        getattr(sensor, "modality", None),
-        getattr(sensor, "orbit", None),
-        bool(getattr(sensor, "use_float_linear", True)),
-        bool(getattr(sensor, "s1_require_iw", True)),
-        bool(getattr(sensor, "s1_relax_iw_on_empty", True)),
-        bool(getattr(sensor, "check_input", False)),
-        bool(getattr(sensor, "check_raise", True)),
-        getattr(sensor, "check_save_dir", None),
-    )
 
 
 def _overrides_base_method(embedder: Any, method_name: str) -> bool:
@@ -465,8 +422,7 @@ def _prepare_embedding_request_context(
     if input_prep_resolved.mode == "tile" and sensor_eff is None:
         sensor_eff = default_sensor_for_model(model_n)
 
-    sensor_k = sensor_key(sensor_eff)
-    embedder, lock = get_embedder_bundle_cached(model_n, backend_n, device_n, sensor_k)
+    embedder, lock = get_embedder_bundle_cached(model_n, backend_n, device_n)
     assert_supported(embedder, backend=backend_n, output=output, temporal=temporal)
 
     return _EmbeddingRequestContext(

--- a/src/rs_embed/tools/serialization.py
+++ b/src/rs_embed/tools/serialization.py
@@ -83,8 +83,17 @@ def embedding_to_numpy(emb: Embedding) -> np.ndarray:
     return np.asarray(emb.data, dtype=np.float32)
 
 
-def sensor_cache_key(sensor: SensorSpec) -> str:
-    obj = {
+def sensor_identity_fields(sensor: SensorSpec, *, include_bands: bool = True) -> dict[str, Any]:
+    """Fetch-affecting identity fields of a :class:`SensorSpec`.
+
+    Single source of truth for every sensor-identity key: adding a
+    fetch-affecting field to ``SensorSpec`` needs exactly one edit here to
+    reach both :func:`sensor_cache_key` (per-sensor cache/manifest identity)
+    and ``providers.prefetch_plan.sensor_fetch_group_key`` (band-superset
+    grouping, which excludes ``bands``).  ``check_*`` fields are deliberately
+    excluded — they cannot affect fetched pixels.
+    """
+    obj: dict[str, Any] = {
         "collection": sensor.collection,
         "bands": list(sensor.bands),
         "scale_m": int(sensor.scale_m),
@@ -97,5 +106,14 @@ def sensor_cache_key(sensor: SensorSpec) -> str:
         "s1_require_iw": bool(getattr(sensor, "s1_require_iw", True)),
         "s1_relax_iw_on_empty": bool(getattr(sensor, "s1_relax_iw_on_empty", True)),
     }
+    if not include_bands:
+        del obj["bands"]
+    return obj
+
+
+def sensor_cache_key(sensor: SensorSpec) -> str:
+    # NOTE: the hash is persisted (export manifests key input refs by it), so
+    # the identity-field names/types above must stay stable across versions.
+    obj = sensor_identity_fields(sensor)
     data = json.dumps(obj, sort_keys=True).encode("utf-8")
     return sanitize_key(hashlib.sha1(data).hexdigest()[:12])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -34,7 +34,6 @@ from rs_embed.core.types import (
 )
 from rs_embed.embedders.base import EmbedderBase
 from rs_embed.tools.output import normalize_embedding_output
-from rs_embed.tools.runtime import sensor_key
 from rs_embed.tools.serialization import sensor_cache_key as _sensor_cache_key
 
 # ── mock embedder ──────────────────────────────────────────────────
@@ -239,7 +238,7 @@ def test_get_embedding_unknown_model():
 
 
 def test_reset_runtime_clears_runtime_and_embedder_module_caches(monkeypatch):
-    rt.get_embedder_bundle_cached("mock_model", "auto", "auto", sensor_key(None))
+    rt.get_embedder_bundle_cached("mock_model", "auto", "auto")
     rt.embedder_accepts_input_chw(type(_MockEmbedder))
     rt.embedder_accepts_model_config(type(_MockVariantEmbedder))
     registry._REGISTRY_IMPORT_ERRORS["remoteclip"] = RuntimeError("boom")
@@ -353,7 +352,7 @@ def test_get_embeddings_batch_empty():
 
 
 def test_get_embeddings_batch_with_sensor():
-    """Ensures sensor param flows through _sensor_key without errors."""
+    """Ensures an explicit sensor flows through the request path without errors."""
 
     sensor = SensorSpec(collection="COLL", bands=("B1",))
     spatials = [PointBuffer(lon=0.0, lat=0.0, buffer_m=256)]
@@ -531,19 +530,8 @@ def test_assert_supported_broken_describe_raises_model_error():
 
 
 # ══════════════════════════════════════════════════════════════════════
-# _sensor_key / _sensor_cache_key
+# _sensor_cache_key
 # ══════════════════════════════════════════════════════════════════════
-
-
-def test_sensor_key_none():
-    assert sensor_key(None) == ("__none__",)
-
-
-def test_sensor_key_deterministic_and_differs():
-    s1 = SensorSpec(collection="A", bands=("B1",), modality="s1")
-    s2 = SensorSpec(collection="A", bands=("B1",), modality="s2")
-    assert sensor_key(s1) == sensor_key(s1)
-    assert sensor_key(s1) != sensor_key(s2)
 
 
 def test_sensor_cache_key_deterministic_and_differs():

--- a/tests/test_combined_flow.py
+++ b/tests/test_combined_flow.py
@@ -50,16 +50,11 @@ def _patch_deps(
         combined_flow, "drop_model_arrays", lambda arrays, m, sanitize_key=None: None
     )
     monkeypatch.setattr(combined_flow, "jsonable", lambda x: x)
-    monkeypatch.setattr(
-        combined_flow,
-        "sensor_key",
-        lambda s: ("__none__",) if s is None else (s.collection,),
-    )
     monkeypatch.setattr(combined_flow, "normalize_model_name", lambda m: m)
     monkeypatch.setattr(
         combined_flow,
         "get_embedder_bundle_cached",
-        lambda model, backend, device, sk: (embedder, lock),
+        lambda model, backend, device: (embedder, lock),
     )
     monkeypatch.setattr(
         combined_flow, "sensor_cache_key", lambda s: s.collection if s else "__none__"
@@ -72,12 +67,7 @@ def _patch_deps(
     monkeypatch.setattr(
         inference_mod,
         "get_embedder_bundle_cached",
-        lambda model, backend, device, sk: (embedder, lock),
-    )
-    monkeypatch.setattr(
-        inference_mod,
-        "sensor_key",
-        lambda s: ("__none__",) if s is None else (s.collection,),
+        lambda model, backend, device: (embedder, lock),
     )
     monkeypatch.setattr(
         inference_mod,

--- a/tests/test_input_prep_tiling.py
+++ b/tests/test_input_prep_tiling.py
@@ -704,7 +704,6 @@ def test_infer_chunk_tile_mode_uses_batch_on_gpu(monkeypatch):
         lambda **kw: _ModelContext(
             embedder=emb,
             lock=lock,
-            sensor_k=("s2",),
             skey=skey,
             needs_provider_input=True,
         ),


### PR DESCRIPTION
Maintainability review item H4 (`MAINTAINABILITY_REVIEW.md`). First of a 3-PR stack (H4 → H5 → H2).

- `get_embedder_bundle_cached` drops the ignored `sensor_k` parameter; the 7 call sites no longer compute a 14-field key that was thrown away. `tools.runtime.sensor_key` deleted (dead); `_ModelContext` drops its never-read `sensor_k` field.
- `sensor_cache_key` and `sensor_fetch_group_key` now derive from a single `sensor_identity_fields()` source, so a new fetch-affecting `SensorSpec` field needs exactly one edit instead of two hand-synced field lists.
- **Compat:** `sensor_cache_key` output verified byte-identical before/after (it is persisted in export manifests); the fetch-group key is in-memory only.

Tests: full suite 987 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)