### PR TITLE
refactor: de-Sentinel-2 the base fetch_input (H5)

### DIFF
--- a/src/rs_embed/embedders/base.py
+++ b/src/rs_embed/embedders/base.py
@@ -9,7 +9,6 @@ from ..core.embedding import Embedding
 from ..core.specs import ModelInputSpec, OutputSpec, SensorSpec, SpatialSpec, TemporalSpec
 from ..core.types import EmbedderCapabilities, FetchResult, declared_capability
 from ..providers.base import ProviderBase
-from ..tools.shape import roi_is_full
 from ..tools.spatial import FULL_WINDOW, square_spatial
 
 
@@ -157,8 +156,9 @@ class EmbedderBase:
 
         from ..providers.fetch import (
             fetch_collection_patch_chw,
-            fetch_s2_multiframe_raw_tchw,
+            fetch_multiframe_patch_raw_tchw,
         )
+        from ..tools.shape import roi_fetch_meta
         from .meta import temporal_to_range
 
         # Embedder entry points resolve temporal via temporal_to_range (None ->
@@ -166,8 +166,11 @@ class EmbedderBase:
         # so normalize here too instead of raising on None / fetching unfiltered.
         temporal = temporal_to_range(temporal)
 
+        # The spec's temporal_mode selects single-composite vs. equal-divided
+        # time-series fetch; both are collection-agnostic and fully driven by
+        # the resolved SensorSpec.
         if spec.temporal_mode == "multi":
-            raw = fetch_s2_multiframe_raw_tchw(
+            raw = fetch_multiframe_patch_raw_tchw(
                 provider,
                 spatial=spatial,
                 temporal=temporal,
@@ -192,8 +195,7 @@ class EmbedderBase:
                 fill_value=fetch_sensor.fill_value,
             )
 
-        meta: dict[str, Any] = {} if roi_is_full(geo_roi) else {"roi_window_geo": geo_roi}
-        return FetchResult(data=raw, meta=meta)
+        return FetchResult(data=raw, meta=roi_fetch_meta(geo_roi) or {})
 
     def tiled_dispatch_model_config(
         self,

--- a/src/rs_embed/embedders/onthefly_agrifm.py
+++ b/src/rs_embed/embedders/onthefly_agrifm.py
@@ -31,7 +31,7 @@ from ..providers.fetch import (
     frame_diversity_meta,
 )
 from ..providers.fetch import (
-    fetch_s2_multiframe_raw_tchw as _fetch_s2_multiframe_raw_tchw,
+    fetch_multiframe_patch_raw_tchw as _fetch_multiframe_patch_raw_tchw,
 )
 from ..providers.resolution import (
     is_provider_backend,
@@ -529,7 +529,7 @@ def _fetch_s2_10_raw_tchw(
     composite: str = "median",
     fill_value: float = 0.0,
 ) -> np.ndarray:
-    return _fetch_s2_multiframe_raw_tchw(
+    return _fetch_multiframe_patch_raw_tchw(
         provider,
         spatial=spatial,
         temporal=temporal,

--- a/src/rs_embed/embedders/onthefly_anysat.py
+++ b/src/rs_embed/embedders/onthefly_anysat.py
@@ -26,7 +26,7 @@ from ..providers.fetch import (
     frame_diversity_meta,
 )
 from ..providers.fetch import (
-    fetch_s2_multiframe_raw_tchw as _fetch_s2_multiframe_raw_tchw,
+    fetch_multiframe_patch_raw_tchw as _fetch_multiframe_patch_raw_tchw,
 )
 from ..providers.resolution import (
     is_provider_backend,
@@ -237,7 +237,7 @@ def _fetch_s2_10_raw_tchw(
     composite: str = "median",
     fill_value: float = 0.0,
 ) -> np.ndarray:
-    raw = _fetch_s2_multiframe_raw_tchw(
+    raw = _fetch_multiframe_patch_raw_tchw(
         provider,
         spatial=spatial,
         temporal=temporal,

--- a/src/rs_embed/embedders/onthefly_galileo.py
+++ b/src/rs_embed/embedders/onthefly_galileo.py
@@ -28,7 +28,7 @@ from ..providers.fetch import (
     frame_diversity_meta,
 )
 from ..providers.fetch import (
-    fetch_s2_multiframe_raw_tchw as _fetch_s2_multiframe_raw_tchw,
+    fetch_multiframe_patch_raw_tchw as _fetch_multiframe_patch_raw_tchw,
 )
 from ..providers.resolution import (
     is_provider_backend,
@@ -281,7 +281,7 @@ def _fetch_s2_10_raw_tchw(
     composite: str = "median",
     fill_value: float = 0.0,
 ) -> np.ndarray:
-    raw = _fetch_s2_multiframe_raw_tchw(
+    raw = _fetch_multiframe_patch_raw_tchw(
         provider,
         spatial=spatial,
         temporal=temporal,

--- a/src/rs_embed/embedders/onthefly_prithvi.py
+++ b/src/rs_embed/embedders/onthefly_prithvi.py
@@ -29,7 +29,7 @@ from ..providers.fetch import (
     fetch_collection_patch_chw as _fetch_collection_patch_chw,
 )
 from ..providers.fetch import (
-    fetch_s2_multiframe_raw_tchw as _fetch_s2_multiframe_raw_tchw,
+    fetch_multiframe_patch_raw_tchw as _fetch_multiframe_patch_raw_tchw,
 )
 from ..providers.resolution import (
     is_provider_backend,
@@ -470,7 +470,7 @@ def _fetch_s2_prithvi6_tchw(
     Bins align with ``temporal_frame_midpoints`` (both use the shared
     ``split_date_range``), so frame ``i`` corresponds to midpoint date ``i``.
     """
-    return _fetch_s2_multiframe_raw_tchw(
+    return _fetch_multiframe_patch_raw_tchw(
         provider,
         spatial=spatial,
         temporal=temporal,

--- a/src/rs_embed/providers/fetch.py
+++ b/src/rs_embed/providers/fetch.py
@@ -248,22 +248,23 @@ def _warn_if_backfilled_frames(arr: np.ndarray, *, collection: str) -> None:
     )
 
 
-def fetch_s2_multiframe_raw_tchw(
+def fetch_multiframe_patch_raw_tchw(
     provider: ProviderBase,
     *,
     spatial: SpatialSpec,
     temporal: TemporalSpec,
     bands: Sequence[str],
+    collection: str,
     n_frames: int = 8,
-    collection: str = "COPERNICUS/S2_SR_HARMONIZED",
     scale_m: int = 10,
     cloudy_pct: int | None = 30,
     composite: str = "median",
     fill_value: float = 0.0,
 ) -> np.ndarray:
-    """Fetch an S2 time series as raw float32 [T,C,H,W] in [0,10000].
+    """Fetch a collection time series as raw float32 [T,C,H,W] in native units.
 
-    Empty sub-windows are back-filled with the whole-window composite; a
+    The window is equal-divided into ``n_frames`` sub-windows.  Empty
+    sub-windows are back-filled with the whole-window composite; a
     ``UserWarning`` is emitted (and the count is recoverable via
     :func:`count_distinct_frames`) so the data-availability gap is not silent.
     """
@@ -278,7 +279,6 @@ def fetch_s2_multiframe_raw_tchw(
             cloudy_pct=(int(cloudy_pct) if cloudy_pct is not None else None),
             composite=str(composite),
             fill_value=float(fill_value),
-            # fetch_fn=_fetch,
         )
     except ProviderError as exc:
         raise ModelError(str(exc)) from exc
@@ -350,7 +350,7 @@ def fetch_collection_binned_raw_tchw(
 ) -> tuple[np.ndarray, dict[str, Any]]:
     """Fetch one composite per explicit time bin as raw float32 [T,C,H,W].
 
-    Unlike :func:`fetch_s2_multiframe_raw_tchw` (equal division of one window),
+    Unlike :func:`fetch_multiframe_patch_raw_tchw` (equal division of one window),
     the caller supplies the exact ``(start, end)`` date bins. Bins with no
     imagery yield all-NaN sentinel frames flagged in the returned meta instead
     of failing or duplicating neighbours; at least one bin must have data.

--- a/tests/test_embedder_base_contracts.py
+++ b/tests/test_embedder_base_contracts.py
@@ -292,7 +292,7 @@ def test_base_fetch_input_multi_defaults_temporal_like_get_embedding(monkeypatch
         seen["temporal"] = temporal
         return np.zeros((2, 1, 4, 4), dtype=np.float32)
 
-    monkeypatch.setattr("rs_embed.providers.fetch.fetch_s2_multiframe_raw_tchw", fake_multi)
+    monkeypatch.setattr("rs_embed.providers.fetch.fetch_multiframe_patch_raw_tchw", fake_multi)
 
     class _MultiModel(EmbedderBase):
         model_name = "multi_dummy"

--- a/tests/test_export_batch.py
+++ b/tests/test_export_batch.py
@@ -2829,7 +2829,7 @@ def test_export_batch_multiframe_prefetch_accepts_tchw_inputs(tmp_path, monkeypa
         "rs_embed.tools.runtime.get_provider", lambda _name, **_kwargs: DummyProvider()
     )
     monkeypatch.setattr(
-        "rs_embed.providers.fetch.fetch_s2_multiframe_raw_tchw",
+        "rs_embed.providers.fetch.fetch_multiframe_patch_raw_tchw",
         lambda provider, **kwargs: np.stack(
             [
                 np.full((3, 6, 6), fill_value=float(t + 1), dtype=np.float32)

--- a/tests/test_runtime_utils_fetch.py
+++ b/tests/test_runtime_utils_fetch.py
@@ -77,11 +77,12 @@ def test_runtime_utils_fetch_multiframe_delegates_to_provider():
             assert isinstance(spatial, BBox)
             return np.ones((4, 3, 2, 5), dtype=np.float32)
 
-    out = ru.fetch_s2_multiframe_raw_tchw(
+    out = ru.fetch_multiframe_patch_raw_tchw(
         _FakeProvider(),
         spatial=BBox(minlon=0.0, minlat=0.0, maxlon=1.0, maxlat=1.0),
         temporal=TemporalSpec.range("2024-01-01", "2024-02-01"),
         bands=("B4", "B3", "B2"),
+        collection="COPERNICUS/S2_SR_HARMONIZED",
         n_frames=4,
     )
     assert out.shape == (4, 3, 2, 5)
@@ -230,11 +231,12 @@ def test_multiframe_fetch_warns_on_backfilled_frames():
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        ru.fetch_s2_multiframe_raw_tchw(
+        ru.fetch_multiframe_patch_raw_tchw(
             _FakeProvider(),
             spatial=BBox(minlon=0.0, minlat=0.0, maxlon=1.0, maxlat=1.0),
             temporal=TemporalSpec.range("2024-01-01", "2024-04-01"),
             bands=("B4", "B3", "B2"),
+            collection="COPERNICUS/S2_SR_HARMONIZED",
             n_frames=4,
         )
     msgs = [str(m.message) for m in w if issubclass(m.category, UserWarning)]
@@ -252,11 +254,12 @@ def test_multiframe_fetch_silent_when_all_frames_distinct():
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        ru.fetch_s2_multiframe_raw_tchw(
+        ru.fetch_multiframe_patch_raw_tchw(
             _FakeProvider(),
             spatial=BBox(minlon=0.0, minlat=0.0, maxlon=1.0, maxlat=1.0),
             temporal=TemporalSpec.range("2024-01-01", "2024-04-01"),
             bands=("B4", "B3", "B2"),
+            collection="COPERNICUS/S2_SR_HARMONIZED",
             n_frames=4,
         )
     assert [m for m in w if "sub-window" in str(m.message)] == []


### PR DESCRIPTION
Maintainability review item H5. Stacked on #111 (merge that first; GitHub will retarget this to main when the base branch is deleted).

- `fetch_s2_multiframe_raw_tchw` → `fetch_multiframe_patch_raw_tchw`: the function was already collection-agnostic (it forwards to the provider's generic multiframe fetch); the name and default collection were the only S2-specific parts. `collection` is now required — every in-tree call site already passed it explicitly.
- `EmbedderBase.fetch_input` no longer names Sentinel-2: both temporal modes are spec-driven and collection-agnostic, and its ROI meta goes through the shared `roi_fetch_meta` helper like every `fetch_input` override instead of a hand-built dict.
- The `temporal_mode` signature divergence flagged in H5 is resolved by the H1 capability declarations (`capabilities.fetch_temporal_mode`) rather than forcing single-frame models to accept a parameter they ignore.

Tests: full suite 987 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)