### PR TITLE
refactor: converge duplicated request/fetch/inference pipelines (H2)

### DIFF
--- a/src/rs_embed/model.py
+++ b/src/rs_embed/model.py
@@ -21,21 +21,11 @@ from .core.specs import (
 )
 from .core.validation import assert_supported, validate_specs
 from .embedders.catalog import MODEL_ALIASES, MODEL_SPECS
-from .tools.model_defaults import (
-    default_sensor_for_model,
-    resolve_sensor_for_model,
-)
-from .tools.normalization import (
-    _resolve_embedding_api_backend,
-    normalize_backend_name,
-    normalize_device_name,
-    normalize_model_name,
-)
+from .tools.model_defaults import resolve_sensor_for_model
+from .tools.normalization import normalize_model_name
 from .tools.runtime import (
-    _EmbeddingRequestContext,
-    get_embedder_bundle_cached,
+    _prepare_embedding_request_context,
     require_model_config_support,
-    resolve_model_aware_input_prep,
     run_embedding_request,
 )
 
@@ -96,60 +86,35 @@ class Model:
         **model_kwargs: Any,
     ) -> None:
         model_config = model_kwargs or None
-        self._model_n = normalize_model_name(name)
-        self._backend_n = _resolve_embedding_api_backend(
-            self._model_n, normalize_backend_name(backend)
-        )
-        self._device = normalize_device_name(device)
         self._output = output
-        self._model_config = model_config
-        (
-            self._input_prep,
-            self._input_prep_resolved,
-            self._input_prep_requested_mode,
-            self._input_prep_model_policy,
-        ) = resolve_model_aware_input_prep(
-            model_n=self._model_n,
-            input_prep=input_prep,
-            output=output,
-        )
 
-        self._sensor = resolve_sensor_for_model(
-            self._model_n,
+        # Same resolution sequence as api.get_embedding: resolve explicit
+        # sensor/fetch/modality overrides first, then let the shared request
+        # context apply normalization, model-aware input_prep, the tile-mode
+        # sensor default, embedder caching, and backend/output support checks.
+        sensor_eff = resolve_sensor_for_model(
+            normalize_model_name(name),
             sensor=sensor,
             fetch=fetch,
             modality=modality,
-            default_when_missing=(self._input_prep_resolved.mode == "tile"),
+            default_when_missing=False,
         )
-        if self._input_prep_resolved.mode == "tile" and self._sensor is None:
-            self._sensor = default_sensor_for_model(self._model_n)
-
-        self._embedder, self._lock = get_embedder_bundle_cached(
-            self._model_n, self._backend_n, self._device
-        )
-        require_model_config_support(
-            embedder=self._embedder,
-            model_config=self._model_config,
-            method_name="get_embedding",
-        )
-        assert_supported(
-            self._embedder,
-            backend=self._backend_n,
-            output=self._output,
+        self._ctx = _prepare_embedding_request_context(
+            model=name,
             temporal=None,
+            sensor=sensor_eff,
+            model_config=model_config,
+            output=output,
+            backend=backend,
+            device=device,
+            input_prep=input_prep,
         )
-        self._ctx = _EmbeddingRequestContext(
-            model_n=self._model_n,
-            backend_n=self._backend_n,
-            device=self._device,
-            sensor_eff=self._sensor,
-            model_config=self._model_config,
-            input_prep=self._input_prep,
-            input_prep_resolved=self._input_prep_resolved,
-            input_prep_requested_mode=self._input_prep_requested_mode,
-            input_prep_model_policy=self._input_prep_model_policy,
-            embedder=self._embedder,
-            lock=self._lock,
+        # Fail fast at construction when model kwargs are unsupported, instead
+        # of on the first embedding call.
+        require_model_config_support(
+            embedder=self._ctx.embedder,
+            model_config=model_config,
+            method_name="get_embedding",
         )
 
     # ── embedding methods ──────────────────────────────────────────
@@ -175,6 +140,12 @@ class Model:
             Normalized embedding output matching this model's ``output`` spec.
         """
         validate_specs(spatial=spatial, temporal=temporal, output=self._output)
+        assert_supported(
+            self._ctx.embedder,
+            backend=self._ctx.backend_n,
+            output=self._output,
+            temporal=temporal,
+        )
         return run_embedding_request(
             spatials=[spatial],
             temporal=temporal,
@@ -211,6 +182,12 @@ class Model:
             raise ModelError("spatials must be a non-empty list[SpatialSpec].")
         for sp in spatials:
             validate_specs(spatial=sp, temporal=temporal, output=self._output)
+        assert_supported(
+            self._ctx.embedder,
+            backend=self._ctx.backend_n,
+            output=self._output,
+            temporal=temporal,
+        )
         return run_embedding_request(
             spatials=spatials,
             temporal=temporal,
@@ -227,7 +204,7 @@ class Model:
             Capability metadata. Returns ``{}`` if unavailable.
         """
         try:
-            desc = self._embedder.describe()
+            desc = self._ctx.embedder.describe()
             return desc if isinstance(desc, dict) else {}
         except Exception as _e:
             return {}

--- a/src/rs_embed/pipelines/inference.py
+++ b/src/rs_embed/pipelines/inference.py
@@ -644,6 +644,120 @@ class InferenceEngine:
             on_done(i)
         return out
 
+    def _dispatch_model_tiers(
+        self,
+        *,
+        idxs: list[int],
+        spatials: list[SpatialSpec],
+        temporal: TemporalSpec | None,
+        sensor: SensorSpec | None,
+        ctx: _ModelContext,
+        backend: str,
+        model_name: str,
+        model_config: dict[str, Any] | None,
+        get_input_fn: Callable[[int], np.ndarray],
+        get_fetch_meta_fn: Callable[[int], dict[str, Any] | None] | None,
+        prefer_batch: bool,
+        use_lock: bool,
+        infer_one_fn: Callable[[int], Embedding],
+        input_prep_resolved: Any,
+        explicit_nonresize: bool,
+        on_done: Callable[[int], None],
+    ) -> dict[int, TaskResult]:
+        """Run the tiered batch/single dispatch for one model over *idxs*.
+
+        Single implementation of the tier ladder shared by per-item chunk
+        inference (:meth:`infer_chunk`) and combined-export model inference
+        (:meth:`infer_model`):
+
+        1. batch with prefetched inputs,
+        2. batch without provider inputs,
+        3. tiled batch (explicit tile mode only),
+        4. per-point fallback for whatever the batch tiers did not finish.
+        """
+        cfg = self.config
+        out: dict[int, TaskResult] = {}
+        can_batch_prefetched, can_batch_no_input, can_batch_tiled = self._evaluate_batch_capability(
+            embedder=ctx.embedder,
+            needs_provider_input=ctx.needs_provider_input,
+            sensor=sensor,
+            skey=ctx.skey,
+            prefer_batch=prefer_batch,
+            allow_nonresize=not explicit_nonresize,
+            input_prep_mode=input_prep_resolved.mode,
+        )
+
+        batch_succeeded = False
+        if can_batch_prefetched:
+            prefetched_out, batch_succeeded = self._run_batch_prefetched(
+                idxs=idxs,
+                spatials=spatials,
+                temporal=temporal,
+                sensor=sensor,
+                embedder=ctx.embedder,
+                lock=ctx.lock,
+                backend=backend,
+                get_input_fn=get_input_fn,
+                batch_size=cfg.effective_infer_batch_size,
+                continue_on_error=cfg.continue_on_error,
+                on_done=on_done,
+                use_lock=use_lock,
+                model_name=model_name,
+                model_config=model_config,
+                get_fetch_meta_fn=get_fetch_meta_fn,
+            )
+            out.update(prefetched_out)
+
+        if not batch_succeeded and can_batch_no_input:
+            batch_out, batch_succeeded = self._run_batch_no_input(
+                idxs=idxs,
+                spatials=spatials,
+                temporal=temporal,
+                sensor=sensor,
+                embedder=ctx.embedder,
+                lock=ctx.lock,
+                backend=backend,
+                batch_size=cfg.effective_infer_batch_size,
+                on_done=on_done,
+                use_lock=use_lock,
+                model_name=model_name,
+                model_config=model_config,
+            )
+            out.update(batch_out)
+
+        if not batch_succeeded and can_batch_tiled:
+            tiled_out, batch_succeeded = self._run_batch_tiled(
+                idxs=idxs,
+                spatials=spatials,
+                temporal=temporal,
+                sensor=sensor,
+                embedder=ctx.embedder,
+                lock=ctx.lock,
+                backend=backend,
+                get_input_fn=get_input_fn,
+                batch_size=cfg.effective_infer_batch_size,
+                continue_on_error=cfg.continue_on_error,
+                on_done=on_done,
+                use_lock=use_lock,
+                model_name=model_name,
+                model_config=model_config,
+                input_prep_resolved=input_prep_resolved,
+                get_fetch_meta_fn=get_fetch_meta_fn,
+            )
+            out.update(tiled_out)
+
+        if not batch_succeeded:
+            fallback_out = self._run_single_fallback(
+                idxs=idxs,
+                already_done=set(out.keys()),
+                infer_one_fn=infer_one_fn,
+                continue_on_error=cfg.continue_on_error,
+                on_done=on_done,
+            )
+            out.update(fallback_out)
+
+        return out
+
     # ── chunk inference (multi-point × multi-model) ────────────────
 
     def infer_chunk(
@@ -663,8 +777,6 @@ class InferenceEngine:
         Returns ``{(point_idx, model_name): TaskResult}``.
         """
         out: dict[tuple[int, str], TaskResult] = {}
-        cfg = self.config
-        infer_bs = cfg.effective_infer_batch_size
 
         for mc in models:
             ctx = self._resolve_model_context(
@@ -724,91 +836,26 @@ class InferenceEngine:
                 except Exception as _e:
                     pass
 
-            can_batch_prefetched, can_batch_no_input, can_batch_tiled = (
-                self._evaluate_batch_capability(
-                    embedder=ctx.embedder,
-                    needs_provider_input=ctx.needs_provider_input,
-                    sensor=mc.sensor,
-                    skey=ctx.skey,
-                    prefer_batch=(self.prefer_batch or mc.is_precomputed),
-                    allow_nonresize=not explicit_nonresize,
-                    input_prep_mode=input_prep_resolved.mode,
-                )
+            model_out = self._dispatch_model_tiers(
+                idxs=idxs,
+                spatials=spatials,
+                temporal=temporal,
+                sensor=mc.sensor,
+                ctx=ctx,
+                backend=mc.backend,
+                model_name=mc.name,
+                model_config=mc.model_config,
+                get_input_fn=_get_input,
+                get_fetch_meta_fn=_get_fmeta,
+                prefer_batch=(self.prefer_batch or mc.is_precomputed),
+                use_lock=False,
+                infer_one_fn=_single,
+                input_prep_resolved=input_prep_resolved,
+                explicit_nonresize=explicit_nonresize,
+                on_done=_mark_done,
             )
-
-            batch_succeeded = False
-            if can_batch_prefetched:
-                prefetched_out, batch_succeeded = self._run_batch_prefetched(
-                    idxs=idxs,
-                    spatials=spatials,
-                    temporal=temporal,
-                    sensor=mc.sensor,
-                    embedder=ctx.embedder,
-                    lock=ctx.lock,
-                    backend=mc.backend,
-                    get_input_fn=_get_input,
-                    batch_size=infer_bs,
-                    continue_on_error=cfg.continue_on_error,
-                    on_done=_mark_done,
-                    use_lock=False,
-                    model_name=mc.name,
-                    model_config=mc.model_config,
-                    get_fetch_meta_fn=_get_fmeta,
-                )
-                for i, rec in prefetched_out.items():
-                    out[(i, mc.name)] = rec
-
-            if not batch_succeeded and can_batch_no_input:
-                batch_out, batch_succeeded = self._run_batch_no_input(
-                    idxs=idxs,
-                    spatials=spatials,
-                    temporal=temporal,
-                    sensor=mc.sensor,
-                    embedder=ctx.embedder,
-                    lock=ctx.lock,
-                    backend=mc.backend,
-                    batch_size=infer_bs,
-                    on_done=_mark_done,
-                    use_lock=False,
-                    model_name=mc.name,
-                    model_config=mc.model_config,
-                )
-                for i, rec in batch_out.items():
-                    out[(i, mc.name)] = rec
-
-            if not batch_succeeded and can_batch_tiled:
-                tiled_out, batch_succeeded = self._run_batch_tiled(
-                    idxs=idxs,
-                    spatials=spatials,
-                    temporal=temporal,
-                    sensor=mc.sensor,
-                    embedder=ctx.embedder,
-                    lock=ctx.lock,
-                    backend=mc.backend,
-                    get_input_fn=_get_input,
-                    batch_size=infer_bs,
-                    continue_on_error=cfg.continue_on_error,
-                    on_done=_mark_done,
-                    use_lock=False,
-                    model_name=mc.name,
-                    model_config=mc.model_config,
-                    input_prep_resolved=input_prep_resolved,
-                    get_fetch_meta_fn=_get_fmeta,
-                )
-                for i, rec in tiled_out.items():
-                    out[(i, mc.name)] = rec
-
-            if not batch_succeeded:
-                already_done = {i for i in idxs if (i, mc.name) in out}
-                fallback_out = self._run_single_fallback(
-                    idxs=idxs,
-                    already_done=already_done,
-                    infer_one_fn=_single,
-                    continue_on_error=cfg.continue_on_error,
-                    on_done=_mark_done,
-                )
-                for i, rec in fallback_out.items():
-                    out[(i, mc.name)] = rec
+            for i, rec in model_out.items():
+                out[(i, mc.name)] = rec
 
         return out
 
@@ -857,8 +904,6 @@ class InferenceEngine:
         """
         cfg = self.config
         n = len(spatials)
-        infer_bs = cfg.effective_infer_batch_size
-        out: dict[int, TaskResult] = {}
         done: set[int] = set()
 
         ctx = self._resolve_model_context(
@@ -920,94 +965,24 @@ class InferenceEngine:
                 backoff_s=cfg.retry_backoff_s,
             )
 
-        can_batch_prefetched, can_batch, can_batch_tiled = self._evaluate_batch_capability(
-            embedder=ctx.embedder,
-            needs_provider_input=ctx.needs_provider_input,
+        return self._dispatch_model_tiers(
+            idxs=list(range(n)),
+            spatials=spatials,
+            temporal=temporal,
             sensor=sensor,
-            skey=ctx.skey,
+            ctx=ctx,
+            backend=model_backend,
+            model_name=model_name,
+            model_config=model_config,
+            get_input_fn=lambda i: get_input_fn(i, ctx.skey, sensor),
+            get_fetch_meta_fn=_batch_fmeta_fn,
             prefer_batch=(allow_batch and prefer_batch),
-            allow_nonresize=not explicit_nonresize,
-            input_prep_mode=input_prep_resolved.mode,
+            use_lock=True,
+            infer_one_fn=_infer_one_with_retry,
+            input_prep_resolved=input_prep_resolved,
+            explicit_nonresize=explicit_nonresize,
+            on_done=_mark_done,
         )
-
-        batch_succeeded = False
-        all_idxs = list(range(n))
-
-        # Tier 1: batch with prefetched inputs (resize/pass-through mode)
-        if can_batch_prefetched:
-            assert ctx.skey is not None and sensor is not None
-            prefetched_out, batch_succeeded = self._run_batch_prefetched(
-                idxs=all_idxs,
-                spatials=spatials,
-                temporal=temporal,
-                sensor=sensor,
-                embedder=ctx.embedder,
-                lock=ctx.lock,
-                backend=model_backend,
-                get_input_fn=lambda i: get_input_fn(i, ctx.skey, sensor),
-                batch_size=infer_bs,
-                continue_on_error=cfg.continue_on_error,
-                on_done=_mark_done,
-                use_lock=True,
-                model_name=model_name,
-                model_config=model_config,
-                get_fetch_meta_fn=_batch_fmeta_fn,
-            )
-            out.update(prefetched_out)
-
-        # Tier 2: batch without inputs
-        if not batch_succeeded and can_batch:
-            batch_out, batch_succeeded = self._run_batch_no_input(
-                idxs=all_idxs,
-                spatials=spatials,
-                temporal=temporal,
-                sensor=sensor,
-                embedder=ctx.embedder,
-                lock=ctx.lock,
-                backend=model_backend,
-                batch_size=infer_bs,
-                on_done=_mark_done,
-                use_lock=True,
-                model_name=model_name,
-                model_config=model_config,
-            )
-            out.update(batch_out)
-
-        # Tier 1.5: tiled batch — tile each image then batch all tiles together
-        if not batch_succeeded and can_batch_tiled:
-            assert ctx.skey is not None and sensor is not None
-            tiled_out, batch_succeeded = self._run_batch_tiled(
-                idxs=all_idxs,
-                spatials=spatials,
-                temporal=temporal,
-                sensor=sensor,
-                embedder=ctx.embedder,
-                lock=ctx.lock,
-                backend=model_backend,
-                get_input_fn=lambda i: get_input_fn(i, ctx.skey, sensor),
-                batch_size=infer_bs,
-                continue_on_error=cfg.continue_on_error,
-                on_done=_mark_done,
-                use_lock=True,
-                model_name=model_name,
-                model_config=model_config,
-                input_prep_resolved=input_prep_resolved,
-                get_fetch_meta_fn=_batch_fmeta_fn,
-            )
-            out.update(tiled_out)
-
-        # Tier 3: single-item fallback
-        if not batch_succeeded:
-            fallback_out = self._run_single_fallback(
-                idxs=all_idxs,
-                already_done=done,
-                infer_one_fn=_infer_one_with_retry,
-                continue_on_error=cfg.continue_on_error,
-                on_done=_mark_done,
-            )
-            out.update(fallback_out)
-
-        return out
 
 
 # ── module-level helpers ───────────────────────────────────────────

--- a/src/rs_embed/pipelines/point_payload.py
+++ b/src/rs_embed/pipelines/point_payload.py
@@ -18,7 +18,7 @@ from ..providers import fetch as _providers_fetch
 from ..tools.manifest import summarize_status
 from ..tools.normalization import normalize_model_name
 from ..tools.runtime import (
-    _embedder_method_accepts_parameter,
+    fetch_embedder_input,
     get_embedder_bundle_cached,
     resolve_model_aware_input_prep,
     run_with_retry,
@@ -31,7 +31,6 @@ from ..tools.serialization import (
     sha1,
     utc_ts,
 )
-from ..tools.shape import square_fetch_request
 from ..tools.tiling import _call_embedder_get_embedding_with_input_prep
 
 
@@ -166,42 +165,27 @@ def build_one_point_payload(
                                 f"Missing provider factory for model={m}, index={point_index}, sensor={skey}"
                             )
                         prov = _get_provider()
+                        # Shared "fetch_input, else generic square fetch" path —
+                        # identical fetch geometry and temporal_mode forwarding
+                        # as the API prefetch (tools.runtime.fetch_embedder_input).
                         fetch_result = run_with_retry(
-                            lambda _p=prov, _ss=sspec, _embedder=embedder: _embedder.fetch_input(
-                                _p,
-                                spatial=spatial,
-                                temporal=temporal,
-                                sensor=_ss,
+                            lambda _p=prov, _ss=sspec, _embedder=embedder, _mcfg=model_config: (
+                                fetch_embedder_input(
+                                    embedder=_embedder,
+                                    provider=_p,
+                                    spatial=spatial,
+                                    temporal=temporal,
+                                    sensor=_ss,
+                                    model_config=_mcfg,
+                                    fetch_fn=fetch,
+                                )
                             ),
                             retries=max_retries,
                             backoff_s=retry_backoff_s,
                         )
-                        if fetch_result is not None:
-                            input_chw = np.asarray(fetch_result.data, dtype=np.float32)
-                            if fetch_result.meta:
-                                local_fetch_meta[skey] = jsonable(fetch_result.meta)
-                        else:
-                            # Generic fallback fetch-squares like every other
-                            # path when the embedder honors the crop-back window.
-                            fetch_spatial, sq_meta = (
-                                square_fetch_request(spatial)
-                                if _embedder_method_accepts_parameter(
-                                    type(embedder), "get_embedding", "fetch_meta"
-                                )
-                                else (spatial, {})
-                            )
-                            input_chw = run_with_retry(
-                                lambda _p=prov, _ss=sspec, _sp=fetch_spatial: fetch(
-                                    _p,
-                                    spatial=_sp,
-                                    temporal=temporal,
-                                    sensor=_ss,
-                                ),
-                                retries=max_retries,
-                                backoff_s=retry_backoff_s,
-                            )
-                            if sq_meta:
-                                local_fetch_meta[skey] = jsonable(sq_meta)
+                        input_chw = np.asarray(fetch_result.data, dtype=np.float32)
+                        if fetch_result.meta:
+                            local_fetch_meta[skey] = jsonable(fetch_result.meta)
                         local_inp[skey] = input_chw
 
                 report = input_reports.get((point_index, skey))

--- a/src/rs_embed/pipelines/prefetch.py
+++ b/src/rs_embed/pipelines/prefetch.py
@@ -156,8 +156,8 @@ class PrefetchManager:
         """
         from ..tools.normalization import normalize_model_name
         from ..tools.runtime import (
-            _embedder_method_accepts_parameter,
             _overrides_base_method,
+            embedder_honors_fetch_meta,
             get_embedder_bundle_cached,
         )
         from ..tools.serialization import sensor_cache_key
@@ -181,7 +181,7 @@ class PrefetchManager:
             )
             meta_safe_by_key[fetch_key] = meta_safe_by_key.get(
                 fetch_key, True
-            ) and _embedder_method_accepts_parameter(type(embedder), "get_embedding", "fetch_meta")
+            ) and embedder_honors_fetch_meta(type(embedder))
             # A merged fetch group may represent a union of channels needed by
             # multiple models. Model-specific fetch_input() implementations
             # generally return only that model's own contract, so using one of

--- a/src/rs_embed/tools/runtime.py
+++ b/src/rs_embed/tools/runtime.py
@@ -492,6 +492,75 @@ def _annotate_embedding_list(
     ]
 
 
+def embedder_honors_fetch_meta(embedder_cls: type) -> bool:
+    """True when ``get_embedding`` accepts ``fetch_meta`` (the crop-back window).
+
+    This is THE gate for generic fetch-squaring: enlarging a rectangular ROI
+    to a square fetch is only safe when the embedder will crop the output back
+    via ``fetch_meta['roi_window_geo']``.  Every pipeline path (API prefetch,
+    per-item sync fallback, PrefetchManager planning) must use this predicate.
+    """
+    return _embedder_method_accepts_parameter(embedder_cls, "get_embedding", "fetch_meta")
+
+
+def fetch_input_extras_from_model_config(
+    embedder_cls: type,
+    model_config: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Fetch-affecting ``fetch_input`` kwargs derived from *model_config*.
+
+    Forwarding these (e.g. ``temporal_mode``) makes every prefetch path fetch
+    the SAME input as the direct ``get_embedding`` path; without it a user's
+    ``temporal_mode="single"`` silently became the env/auto default.
+    """
+    extras: dict[str, Any] = {}
+    if model_config and _embedder_method_accepts_parameter(
+        embedder_cls, "fetch_input", "temporal_mode"
+    ):
+        tm = model_config.get("temporal_mode")
+        if tm is not None:
+            extras["temporal_mode"] = tm
+    return extras
+
+
+def fetch_embedder_input(
+    *,
+    embedder: Any,
+    provider: Any,
+    spatial: SpatialSpec,
+    temporal: TemporalSpec | None,
+    sensor: SensorSpec,
+    model_config: dict[str, Any] | None = None,
+    fetch_fn: Callable[..., np.ndarray] | None = None,
+) -> FetchResult:
+    """The single "embedder ``fetch_input``, else generic square fetch" path.
+
+    Every pipeline that fetches provider input on behalf of an embedder goes
+    through here so the fetch geometry is identical everywhere: the embedder's
+    own ``fetch_input`` wins; the generic fallback enlarges the ROI to a
+    fetch-square exactly when :func:`embedder_honors_fetch_meta` says the
+    crop-back window will be honored.
+    """
+    from .shape import square_fetch_request
+
+    fr = embedder.fetch_input(
+        provider,
+        spatial=spatial,
+        temporal=temporal,
+        sensor=sensor,
+        **fetch_input_extras_from_model_config(type(embedder), model_config),
+    )
+    if fr is not None:
+        return fr
+    if embedder_honors_fetch_meta(type(embedder)):
+        fetch_spatial, fmeta = square_fetch_request(spatial)
+    else:
+        fetch_spatial, fmeta = spatial, {}
+    fn = fetch_fn or _fetch_sensor_patch_chw
+    raw = fn(provider, spatial=fetch_spatial, temporal=temporal, sensor=sensor)
+    return FetchResult(data=raw, meta=fmeta)
+
+
 def fetch_api_side_inputs(
     *,
     spatials: list[SpatialSpec],
@@ -537,50 +606,19 @@ def fetch_api_side_inputs(
     if callable(ensure_ready):
         run_with_retry(lambda: ensure_ready(), retries=0, backoff_s=0.0)
 
-    # Forward fetch-affecting model_config (e.g. temporal_mode) so the prefetch
-    # path fetches the SAME input as the direct get_embedding path. Without this
-    # the prefetch used fetch_input's defaults and silently ignored the user's
-    # config (e.g. temporal_mode="single" became multi via the env/auto default).
-    fetch_extra: dict[str, Any] = {}
-    if model_config and _embedder_method_accepts_parameter(
-        type(embedder), "fetch_input", "temporal_mode"
-    ):
-        tm = model_config.get("temporal_mode")
-        if tm is not None:
-            fetch_extra["temporal_mode"] = tm
-
-    # Use the embedder's fetch_input() when available; fall back to generic.
-    # The generic fallback fetch-squares like every other path (fetch_input's
-    # square_input=True default, PrefetchManager's square_fetch_keys) whenever
-    # the embedder honors the crop-back window via fetch_meta.
-    from .shape import square_fetch_request
-
-    square_generic = _embedder_method_accepts_parameter(
-        type(embedder), "get_embedding", "fetch_meta"
-    )
     results: list[FetchResult] = []
     for idx, spatial in enumerate(spatials):
         try:
-            fr = embedder.fetch_input(
-                provider,
-                spatial=spatial,
-                temporal=temporal,
-                sensor=sensor_eff,
-                **fetch_extra,
-            )
-            if fr is not None:
-                results.append(fr)
-            else:
-                fetch_spatial, fmeta = (
-                    square_fetch_request(spatial) if square_generic else (spatial, {})
-                )
-                raw = _fetch_sensor_patch_chw(
-                    provider,
-                    spatial=fetch_spatial,
+            results.append(
+                fetch_embedder_input(
+                    embedder=embedder,
+                    provider=provider,
+                    spatial=spatial,
                     temporal=temporal,
                     sensor=sensor_eff,
+                    model_config=model_config,
                 )
-                results.append(FetchResult(data=raw, meta=fmeta))
+            )
         except Exception as exc:
             raise ModelError(
                 f"Failed to fetch API-side input for spatial[{idx}] ({spatial}): {exc}"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -130,7 +130,7 @@ _TEMPORAL = TemporalSpec.year(2024)
 
 def test_model_init_happy_path():
     m = Model("mock_model")
-    assert m._model_n == "mock_model"
+    assert m._ctx.model_n == "mock_model"
 
 
 def test_model_init_unknown_model_raises():
@@ -141,18 +141,18 @@ def test_model_init_unknown_model_raises():
 def test_model_init_with_modality_resolves_sensor():
     registry.register("mock_multi")(_MockMultimodalEmbedder)
     m = Model("mock_multi", modality="s1", backend="gee")
-    assert m._sensor is not None
-    assert m._sensor.modality == "s1"
-    assert m._sensor.collection == "COPERNICUS/S1_GRD_FLOAT"
+    assert m._ctx.sensor_eff is not None
+    assert m._ctx.sensor_eff.modality == "s1"
+    assert m._ctx.sensor_eff.collection == "COPERNICUS/S1_GRD_FLOAT"
 
 
 def test_model_init_with_fetch_resolves_sensor():
     registry.register("mock_multi")(_MockMultimodalEmbedder)
     m = Model("mock_multi", fetch=FetchSpec(scale_m=30), backend="gee")
-    assert m._sensor is not None
-    assert m._sensor.modality == "s2"
-    assert m._sensor.collection == "COPERNICUS/S2_SR_HARMONIZED"
-    assert m._sensor.scale_m == 30
+    assert m._ctx.sensor_eff is not None
+    assert m._ctx.sensor_eff.modality == "s2"
+    assert m._ctx.sensor_eff.collection == "COPERNICUS/S2_SR_HARMONIZED"
+    assert m._ctx.sensor_eff.scale_m == 30
 
 
 def test_model_init_rejects_sensor_and_fetch_together():
@@ -268,7 +268,7 @@ def test_model_describe_returns_dict():
 def test_model_describe_graceful_on_exception(monkeypatch):
     m = Model("mock_model")
     monkeypatch.setattr(
-        m._embedder, "describe", lambda: (_ for _ in ()).throw(RuntimeError("oops"))
+        m._ctx.embedder, "describe", lambda: (_ for _ in ()).throw(RuntimeError("oops"))
     )
     assert m.describe() == {}
 
@@ -302,19 +302,19 @@ def test_model_and_functional_api_produce_same_shape():
 def test_model_reuses_same_embedder_across_calls():
     """Two calls on the same Model must use the same underlying embedder instance."""
     m = Model("mock_model")
-    embedder_id_1 = id(m._embedder)
+    embedder_id_1 = id(m._ctx.embedder)
 
     m.get_embedding(_SPATIAL)
     m.get_embedding(_SPATIAL)
 
-    assert id(m._embedder) == embedder_id_1
+    assert id(m._ctx.embedder) == embedder_id_1
 
 
 def test_two_model_instances_share_cached_embedder():
     """Two Model instances with the same args should share the lru_cache entry."""
     m1 = Model("mock_model")
     m2 = Model("mock_model")
-    assert m1._embedder is m2._embedder
+    assert m1._ctx.embedder is m2._ctx.embedder
 
 
 # ══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Maintainability review item H2 (= REVIEW_FIXES 6.7 follow-up). Stacked on #111 and the H5 PR; merge those first.

- **Model class dedup:** `Model.__init__` now builds its request context via the shared `_prepare_embedding_request_context` instead of a hand-copied (and drifted) version. Temporal support is now asserted per call like the function API — previously a `Model` instance only checked `temporal=None` once at construction, so the class and function APIs could disagree on unsupported temporals.
- **One fetch fallback:** the "embedder `fetch_input`, else generic square fetch" path was implemented 4× with two different gating policies; it is now a single `tools.runtime.fetch_embedder_input` helper, with `embedder_honors_fetch_meta` as the one squaring gate (also used by `PrefetchManager` planning). The per-item sync fallback now forwards `temporal_mode` from `model_config` like the API prefetch path, closing a fetch-consistency gap the code comments had warned about.
- **One tier ladder:** `InferenceEngine._dispatch_model_tiers` is the single implementation of the prefetched-batch → no-input-batch → tiled-batch → per-point-fallback dispatch; `infer_chunk` and `infer_model` both delegate to it (removes ~170 duplicated lines; net −30 lines).

Known remainder (tracked in `MAINTAINABILITY_REVIEW.md`): `point_payload.build_one_point_payload`'s overall assembly flow is still separate — its fetch and single-call steps now go through the shared helpers, but full unification is a larger refactor.

Tests: full suite 987 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)