### PR TITLE
fix: output-spec validation at construction; temporal meta on tensor paths; batch model_config contract (M7/M8/M9)

### DIFF
--- a/src/rs_embed/core/specs.py
+++ b/src/rs_embed/core/specs.py
@@ -350,6 +350,21 @@ class OutputSpec:
     # - native: keep model/provider native orientation.
     grid_orientation: Literal["north_up", "native"] = "north_up"
 
+    def __post_init__(self) -> None:
+        # Validate at construction so an invalid mode/pooling can never reach
+        # an embedder: several pooling implementations dispatch with a plain
+        # if/else, where an unvalidated typo would silently produce a wrong
+        # (mean-pooled) result instead of an error.
+        if self.mode not in ("grid", "pooled"):
+            raise SpecError(f"Unknown output mode: {self.mode!r} (expected 'grid' or 'pooled').")
+        if self.pooling not in ("mean", "max"):
+            raise SpecError(f"Unknown pooling: {self.pooling!r} (expected 'mean' or 'max').")
+        if self.grid_orientation not in ("north_up", "native"):
+            raise SpecError(
+                f"Unknown grid_orientation: {self.grid_orientation!r} "
+                "(expected 'north_up' or 'native')."
+            )
+
     @staticmethod
     def grid(
         *,

--- a/src/rs_embed/embedders/onthefly_agrifm.py
+++ b/src/rs_embed/embedders/onthefly_agrifm.py
@@ -616,6 +616,7 @@ class AgriFMEmbedder(EmbedderBase):
         input_chw=True,
         fetch_meta=True,
         batch_fetch_metas=True,
+        model_config_batch=True,
         model_config_batch_inputs=True,
     )
 
@@ -832,10 +833,15 @@ class AgriFMEmbedder(EmbedderBase):
         spatials: list[SpatialSpec],
         temporal: TemporalSpec | None = None,
         sensor: SensorSpec | None = None,
+        model_config: dict[str, Any] | None = None,
         output: OutputSpec = OutputSpec.pooled(),
         backend: str = "auto",
         device: str = "auto",
     ) -> list[Embedding]:
+        if model_config is not None:
+            # Same contract as the base batch path: an unsupported
+            # model_config raises ModelError instead of TypeError/silence.
+            self._require_model_config_support(model_config)
         if not spatials:
             return []
         if not is_provider_backend(backend, allow_auto=True):

--- a/src/rs_embed/embedders/onthefly_fomo.py
+++ b/src/rs_embed/embedders/onthefly_fomo.py
@@ -770,6 +770,10 @@ class FoMoEmbedder(EmbedderBase):
         device: str = "auto",
         fetch_metas: list[dict[str, Any] | None] | None = None,
     ) -> list[Embedding]:
+        if len(spatials) != len(input_chws):
+            raise ValueError(
+                f"spatials/input_chws length mismatch: {len(spatials)} != {len(input_chws)}"
+            )
         if not input_chws:
             return []
 

--- a/src/rs_embed/embedders/onthefly_terrafm.py
+++ b/src/rs_embed/embedders/onthefly_terrafm.py
@@ -724,7 +724,12 @@ class TerraFMBEmbedder(EmbedderBase):
             want_grid=(output.mode == "grid" or cropped_to_roi),
         )
 
-        temporal_used = temporal_to_range(temporal) if uses_provider else None
+        # Provider fetches always record the resolved window. Tensor inputs
+        # record it only when the caller supplied a temporal (it describes
+        # their data); otherwise the window is genuinely unknown -> None.
+        temporal_used = (
+            temporal_to_range(temporal) if (uses_provider or temporal is not None) else None
+        )
         sensor_meta = None
         source = None
         if uses_provider:
@@ -982,7 +987,12 @@ class TerraFMBEmbedder(EmbedderBase):
         dev = str(wmeta.get("device", _auto_device(device)))
         infer_bs = self._resolve_infer_batch(dev)
 
-        temporal_used = temporal_to_range(temporal) if uses_provider else None
+        # Provider fetches always record the resolved window. Tensor inputs
+        # record it only when the caller supplied a temporal (it describes
+        # their data); otherwise the window is genuinely unknown -> None.
+        temporal_used = (
+            temporal_to_range(temporal) if (uses_provider or temporal is not None) else None
+        )
         sensor_meta = None
         source = None
         if uses_provider and modality == "s2":

--- a/src/rs_embed/embedders/onthefly_terramind.py
+++ b/src/rs_embed/embedders/onthefly_terramind.py
@@ -679,6 +679,10 @@ class TerraMindEmbedder(EmbedderBase):
                     "backend='tensor' requires input_chw as CHW. "
                     "Use get_embeddings_batch_from_inputs(...) for batches."
                 )
+            # Tensor inputs: record the caller's resolved window when supplied
+            # (it describes their data); otherwise it is genuinely unknown.
+            if temporal is not None:
+                temporal_used = temporal_to_range(temporal)
             x_bchw = _prepare_terramind_input_chw(
                 input_chw,
                 image_size=image_size,
@@ -930,7 +934,9 @@ class TerraMindEmbedder(EmbedderBase):
 
         backend_l = backend.lower().strip()
         uses_provider = backend_l != "tensor"
-        t = None
+        # Tensor inputs: record the caller's resolved window when supplied
+        # (it describes their data); otherwise it is genuinely unknown.
+        t = temporal_to_range(temporal) if temporal is not None else None
         fill_value = 0.0
         source = None
         sensor_meta = None

--- a/src/rs_embed/embedders/onthefly_wildsat.py
+++ b/src/rs_embed/embedders/onthefly_wildsat.py
@@ -1211,6 +1211,10 @@ class WildSATEmbedder(EmbedderBase):
         device: str = "auto",
         fetch_metas: list[dict[str, Any] | None] | None = None,
     ) -> list[Embedding]:
+        if len(spatials) != len(input_chws):
+            raise ValueError(
+                f"spatials/input_chws length mismatch: {len(spatials)} != {len(input_chws)}"
+            )
         if not input_chws:
             return []
 

--- a/src/rs_embed/embedders/precomputed_copernicus_embed.py
+++ b/src/rs_embed/embedders/precomputed_copernicus_embed.py
@@ -107,6 +107,7 @@ class CopernicusEmbedder(EmbedderBase):
     # match the actual method signatures (tests/test_capabilities_contract.py).
     capabilities = EmbedderCapabilities(
         batch_fetch_metas=True,
+        model_config_batch=True,
         model_config_batch_inputs=True,
     )
 
@@ -223,7 +224,7 @@ class CopernicusEmbedder(EmbedderBase):
             backend="vendored_geotiff",
             source="hf://torchgeo/copernicus_embed/embed_map_310k.tif",
             sensor=None,
-            temporal=None,
+            temporal=temporal,
             image_size=None,
             extra={
                 "data_dir": data_dir,
@@ -271,10 +272,15 @@ class CopernicusEmbedder(EmbedderBase):
         spatials: list[SpatialSpec],
         temporal: TemporalSpec | None = None,
         sensor: SensorSpec | None = None,
+        model_config: dict[str, Any] | None = None,
         output: OutputSpec = OutputSpec.pooled(),
         backend: str = "auto",
         device: str = "auto",
     ) -> list[Embedding]:
+        if model_config is not None:
+            # Same contract as the base batch path: an unsupported
+            # model_config raises ModelError instead of TypeError/silence.
+            self._require_model_config_support(model_config)
         if not spatials:
             return []
 

--- a/src/rs_embed/embedders/precomputed_gse_annual.py
+++ b/src/rs_embed/embedders/precomputed_gse_annual.py
@@ -73,6 +73,7 @@ class GSEAnnualEmbedder(EmbedderBase):
     # match the actual method signatures (tests/test_capabilities_contract.py).
     capabilities = EmbedderCapabilities(
         batch_fetch_metas=True,
+        model_config_batch=True,
         model_config_batch_inputs=True,
     )
 
@@ -184,15 +185,18 @@ class GSEAnnualEmbedder(EmbedderBase):
                 raise ModelError(f"Unknown pooling='{output.pooling}' (expected 'mean' or 'max').")
             return Embedding(data=vec, meta={**meta, "pooling": output.pooling})
 
-        # grid: return xarray with dims (band,y,x)
-        da = xr.DataArray(
-            emb_chw,
-            dims=("d", "y", "x"),
-            coords={"d": list(band_names)},
-            name="embedding",
-            attrs=meta,
-        )
-        return Embedding(data=da, meta=meta)
+        if output.mode == "grid":
+            # grid: return xarray with dims (band,y,x)
+            da = xr.DataArray(
+                emb_chw,
+                dims=("d", "y", "x"),
+                coords={"d": list(band_names)},
+                name="embedding",
+                attrs=meta,
+            )
+            return Embedding(data=da, meta=meta)
+
+        raise ModelError(f"Unknown output mode: {output.mode}")
 
     def _fetch_tiled(
         self,
@@ -237,10 +241,15 @@ class GSEAnnualEmbedder(EmbedderBase):
         spatials: list[SpatialSpec],
         temporal: TemporalSpec | None = None,
         sensor: SensorSpec | None = None,
+        model_config: dict[str, Any] | None = None,
         output: OutputSpec = OutputSpec.pooled(),
         backend: str = "auto",
         device: str = "auto",
     ) -> list[Embedding]:
+        if model_config is not None:
+            # Same contract as the base batch path: an unsupported
+            # model_config raises ModelError instead of TypeError/silence.
+            self._require_model_config_support(model_config)
         if not spatials:
             return []
         if not is_provider_backend(backend, allow_auto=True):

--- a/src/rs_embed/embedders/precomputed_tessera.py
+++ b/src/rs_embed/embedders/precomputed_tessera.py
@@ -76,7 +76,7 @@ def _pool(chw: np.ndarray, pooling: str) -> np.ndarray:
         return chw.mean(axis=(1, 2)).astype(np.float32)
     if pooling == "max":
         return chw.max(axis=(1, 2)).astype(np.float32)
-    raise ModelError(f"Unknown pooling: {pooling}")
+    raise ModelError(f"Unknown pooling={pooling!r} (expected 'mean' or 'max').")
 
 
 def _to_hwc(arr: np.ndarray) -> np.ndarray:
@@ -294,6 +294,7 @@ class TesseraEmbedder(EmbedderBase):
     # match the actual method signatures (tests/test_capabilities_contract.py).
     capabilities = EmbedderCapabilities(
         batch_fetch_metas=True,
+        model_config_batch=True,
         model_config_batch_inputs=True,
     )
 
@@ -434,10 +435,15 @@ class TesseraEmbedder(EmbedderBase):
         spatials: list[SpatialSpec],
         temporal: TemporalSpec | None = None,
         sensor: SensorSpec | None = None,
+        model_config: dict[str, Any] | None = None,
         output: OutputSpec = OutputSpec.pooled(),
         backend: str = "auto",
         device: str = "auto",
     ) -> list[Embedding]:
+        if model_config is not None:
+            # Same contract as the base batch path: an unsupported
+            # model_config raises ModelError instead of TypeError/silence.
+            self._require_model_config_support(model_config)
         if not spatials:
             return []
 

--- a/src/rs_embed/pipelines/inference.py
+++ b/src/rs_embed/pipelines/inference.py
@@ -219,7 +219,8 @@ class InferenceEngine:
         can_batch_no_input = (
             prefer_batch and supports_batch_api(embedder) and not needs_provider_input
         )
-        # Tier 1.5: batch across multiple spatial points, each tiled internally.
+        # Tiled batch (third in the dispatch order — see _dispatch_model_tiers):
+        # batch across multiple spatial points, each tiled internally.
         # Only for explicit tile mode — auto mode requires per-image size inspection
         # which can't be batched without first fetching every image.
         can_batch_tiled = (

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -434,6 +434,20 @@ def test_validate_specs_rejects_legacy_output_scale_m():
         _validate_specs(spatial=_SPATIAL, temporal=None, output=bad_output)
 
 
+def test_output_spec_rejects_invalid_values_at_construction():
+    """Regression (review M8): an invalid mode/pooling must be impossible to
+    construct — several embedders dispatch pooling with a plain if/else where
+    an unvalidated typo silently produced mean-pooled results."""
+    from rs_embed.core.errors import SpecError
+
+    with pytest.raises(SpecError, match="Unknown output mode"):
+        OutputSpec(mode="gird")
+    with pytest.raises(SpecError, match="Unknown pooling"):
+        OutputSpec(mode="pooled", pooling="median")
+    with pytest.raises(SpecError, match="Unknown grid_orientation"):
+        OutputSpec(mode="grid", grid_orientation="south_up")
+
+
 def test_validate_specs_bad_pooling():
     bad_output = OutputSpec.__new__(OutputSpec)
     object.__setattr__(bad_output, "mode", "pooled")

--- a/tests/test_batch_overrides_all_models.py
+++ b/tests/test_batch_overrides_all_models.py
@@ -1,6 +1,8 @@
 import numpy as np
+import pytest
 
 from rs_embed.core.embedding import Embedding
+from rs_embed.core.errors import ModelError
 from rs_embed.core.specs import OutputSpec, PointBuffer, SensorSpec, TemporalSpec
 from rs_embed.embedders.onthefly_agrifm import AgriFMEmbedder
 from rs_embed.embedders.onthefly_anysat import AnySatEmbedder
@@ -832,3 +834,19 @@ def test_satmaepp_batch_outputs_align_with_spatials(monkeypatch):
 
     assert sum(slice_sizes) == len(spatials)
     assert [float(e.data[0]) for e in out] == [10.0, 11.0, 12.0, 13.0]
+
+
+@pytest.mark.parametrize(
+    "embedder_cls",
+    [AgriFMEmbedder, GSEAnnualEmbedder, TesseraEmbedder, CopernicusEmbedder],
+)
+def test_batch_rejects_unsupported_model_config_with_model_error(embedder_cls):
+    """Regression (review M7): these batch overrides had no model_config
+    parameter at all, so the pipeline forwarding one crashed with TypeError
+    instead of the base contract's ModelError."""
+    emb = embedder_cls()
+    with pytest.raises(ModelError, match="does not accept model-specific"):
+        emb.get_embeddings_batch(
+            spatials=_spatials(1),
+            model_config={"variant": "large"},
+        )

--- a/tests/test_precomputed_copernicus_embed.py
+++ b/tests/test_precomputed_copernicus_embed.py
@@ -59,6 +59,9 @@ def test_copernicus_embedder_pooled_output_uses_vendored_meta(monkeypatch):
         )
 
     np.testing.assert_allclose(emb.data, np.array([4.0, 5.0], dtype=np.float32))
+    # Regression (review M9): the served year must be recorded, not {"mode": None}.
+    assert emb.meta["temporal"]["mode"] == "year"
+    assert emb.meta["temporal"]["year"] == 2021
     assert emb.meta["backend"] == "vendored_geotiff"
     assert emb.meta["source"] == "hf://torchgeo/copernicus_embed/embed_map_310k.tif"
     assert emb.meta["dataset_path"] == "/tmp/copernicus/embed_map_310k.tif"


### PR DESCRIPTION
Batch 1 of the M-level maintainability fixes (`MAINTAINABILITY_REVIEW.md`). First of a 3-PR stack — merge in order: this → M2/M3/M11 → M5/M13.

## M8 — invalid output/pooling can no longer produce silently wrong results
`OutputSpec.__post_init__` validates mode/pooling/grid_orientation at construction (mechanism fix: ~20 embedder pooling sites dispatch with a plain if/else where a typo silently meant mean-pooling — an invalid value now cannot reach any of them). gse gains the explicit unknown-output-mode raise every other embedder has; tessera's pooling error message gains the expected-values hint.

## M9 — temporal meta honesty
copernicus records the resolved served year (it resolved the year then recorded None). terrafm/terramind tensor paths record the caller's resolved window when supplied; when no temporal is given for user-supplied tensors the window is genuinely unknown and stays None.

## M7 — batch method contracts
agrifm + gse/tessera/copernicus `get_embeddings_batch` accept `model_config` and reject unsupported settings with the base contract's ModelError (previously TypeError); wildsat/fomo `get_embeddings_batch_from_inputs` restore the base length-mismatch guard; stale "Tier 1.5" comment now states the actual dispatch order. Capabilities declarations updated (contract-tested).

Tests: full suite green at this tip (1016 passed, 4 skipped), incl. new regression tests for OutputSpec validation, copernicus temporal meta, and the batch model_config contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)