### PR TITLE
refactor: extract shared embedder helpers (M10-a)

### DIFF
--- a/src/rs_embed/embedders/meta.py
+++ b/src/rs_embed/embedders/meta.py
@@ -149,3 +149,31 @@ def build_meta(
         meta.update(extra)
 
     return meta
+
+
+def base_meta(
+    *,
+    model_name,
+    hf_id,
+    backend,
+    image_size,
+    sensor,
+    temporal=None,
+    source=None,
+    embed_type="on_the_fly",
+    extra=None,
+):
+    """``build_meta`` wrapper for on-the-fly embedders that record an ``hf_id``."""
+    m = build_meta(
+        model=model_name,
+        kind=embed_type,
+        backend=backend,
+        source=source or getattr(sensor, "collection", None),
+        sensor=sensor,
+        temporal=temporal,
+        image_size=image_size,
+    )
+    m["hf_id"] = hf_id
+    if extra:
+        m.update(extra)
+    return m

--- a/src/rs_embed/embedders/onthefly_agrifm.py
+++ b/src/rs_embed/embedders/onthefly_agrifm.py
@@ -12,7 +12,6 @@ from functools import lru_cache
 from typing import Any
 
 import numpy as np
-import xarray as xr
 
 from ..core.embedding import Embedding
 from ..core.errors import ModelError
@@ -53,6 +52,7 @@ from ..tools.shape import (
 from ..tools.spatial import square_spatial
 from .base import EmbedderBase
 from .meta import build_meta, temporal_to_range
+from .shared import grid_to_dataarray, verify_loaded_params
 
 
 def ensure_torch() -> None:
@@ -422,25 +422,12 @@ def _resolve_ckpt_path() -> str:
 
 def _assert_weights_loaded(model) -> dict[str, float]:
     ensure_torch()
-    import torch
-
-    p = None
-    for _, param in model.named_parameters():
-        if param is not None and param.numel() > 0:
-            p = param.detach()
-            break
-    if p is None:
-        raise ModelError("AgriFM model has no parameters; cannot verify weights.")
-    if not torch.isfinite(p).all():
-        raise ModelError("AgriFM parameters contain NaN/Inf; checkpoint load likely failed.")
-
-    p_f = p.float()
-    std = float(p_f.std().cpu())
-    mx = float(p_f.abs().max().cpu())
-    mean = float(p_f.mean().cpu())
-    if std < 1e-6 and mx < 1e-5:
-        raise ModelError("AgriFM parameters look uninitialized (near-zero stats).")
-    return {"param_mean": mean, "param_std": std, "param_absmax": mx}
+    return verify_loaded_params(
+        model,
+        model_name="AgriFM",
+        nonfinite_msg="AgriFM parameters contain NaN/Inf; checkpoint load likely failed.",
+        check_near_zero=True,
+    )
 
 
 @lru_cache(maxsize=6)
@@ -812,17 +799,7 @@ class AgriFMEmbedder(EmbedderBase):
             return Embedding(data=vec, meta=meta)
 
         if output.mode == "grid":
-            da = xr.DataArray(
-                grid.astype(np.float32),
-                dims=("d", "y", "x"),
-                coords={
-                    "d": np.arange(grid.shape[0]),
-                    "y": np.arange(grid.shape[1]),
-                    "x": np.arange(grid.shape[2]),
-                },
-                name="embedding",
-                attrs=meta,
-            )
+            da = grid_to_dataarray(grid.astype(np.float32), meta=meta)
             return Embedding(data=da, meta=meta)
 
         raise ModelError(f"Unknown output mode: {output.mode}")

--- a/src/rs_embed/embedders/onthefly_anysat.py
+++ b/src/rs_embed/embedders/onthefly_anysat.py
@@ -7,7 +7,6 @@ from functools import lru_cache
 from typing import Any
 
 import numpy as np
-import xarray as xr
 
 from ..core.embedding import Embedding
 from ..core.errors import ModelError
@@ -53,6 +52,7 @@ from ..tools.temporal import temporal_frame_midpoints
 from .base import EmbedderBase
 from .config import model_config_value
 from .meta import build_meta, temporal_to_range
+from .shared import grid_to_dataarray, verify_loaded_params
 
 
 def ensure_torch() -> None:
@@ -318,7 +318,6 @@ def _load_anysat_cached(
     dev: str,
 ) -> tuple[Any, dict[str, Any]]:
     ensure_torch()
-    import torch
 
     hub = _load_anysat_hub_module()
     if not hasattr(hub, "AnySat"):
@@ -352,16 +351,12 @@ def _load_anysat_cached(
 
     model = _move_model_to_device(model, dev, model_name="AnySat")
 
-    p0 = None
-    for _, p in model.named_parameters():
-        if p is not None and p.numel() > 0:
-            p0 = p.detach()
-            break
-    if p0 is None:
-        raise ModelError("AnySat model has no parameters; cannot verify load.")
-    if not torch.isfinite(p0).all():
-        raise ModelError("AnySat parameters contain NaN/Inf; checkpoint load likely failed.")
-    p0f = p0.float()
+    wstats = verify_loaded_params(
+        model,
+        model_name="AnySat",
+        no_params_msg="AnySat model has no parameters; cannot verify load.",
+        nonfinite_msg="AnySat parameters contain NaN/Inf; checkpoint load likely failed.",
+    )
 
     meta = {
         "model_size": str(model_size),
@@ -370,9 +365,7 @@ def _load_anysat_cached(
         "loaded_from": loaded_from,
         "model_source": "vendored_rs_embed_runtime",
         "device": dev,
-        "param_mean": float(p0f.mean().cpu()),
-        "param_std": float(p0f.std().cpu()),
-        "param_absmax": float(p0f.abs().max().cpu()),
+        **wstats,
     }
     return model, meta
 
@@ -787,17 +780,7 @@ class AnySatEmbedder(EmbedderBase):
                 "grid_hw": (int(grid.shape[1]), int(grid.shape[2])),
                 "grid_shape": tuple(grid.shape),
             }
-            da = xr.DataArray(
-                grid.astype(np.float32),
-                dims=("d", "y", "x"),
-                coords={
-                    "d": np.arange(grid.shape[0]),
-                    "y": np.arange(grid.shape[1]),
-                    "x": np.arange(grid.shape[2]),
-                },
-                name="embedding",
-                attrs=gmeta,
-            )
+            da = grid_to_dataarray(grid.astype(np.float32), meta=gmeta)
             return Embedding(data=da, meta=gmeta)
 
         raise ModelError(f"Unknown output mode: {output.mode}")

--- a/src/rs_embed/embedders/onthefly_dofa.py
+++ b/src/rs_embed/embedders/onthefly_dofa.py
@@ -7,7 +7,6 @@ from functools import lru_cache
 from typing import Any
 
 import numpy as np
-import xarray as xr
 
 from ..core.embedding import Embedding
 from ..core.errors import ModelError
@@ -44,6 +43,7 @@ from ..tools.spatial import FULL_WINDOW, square_spatial
 from ._vendor.dofa_vit import vit_base_patch16, vit_large_patch16
 from .base import EmbedderBase
 from .meta import build_meta, temporal_to_range
+from .shared import grid_to_dataarray, verify_loaded_params
 
 # -----------------------------
 # Defaults: Sentinel-2 SR (official DOFA 9-band order)
@@ -464,15 +464,12 @@ def _load_dofa_model_cached(variant: str, dev: str):
     model = model.to(dev).eval()
 
     # sanity
-    p0 = None
-    for _, p in model.named_parameters():
-        if p is not None and p.numel() > 0:
-            p0 = p.detach()
-            break
-    if p0 is None:
-        raise ModelError("DOFA model has no parameters; unexpected.")
-    if not torch.isfinite(p0).all():
-        raise ModelError("DOFA parameters contain NaN/Inf; weight load likely failed.")
+    verify_loaded_params(
+        model,
+        model_name="DOFA",
+        no_params_msg="DOFA model has no parameters; unexpected.",
+        nonfinite_msg="DOFA parameters contain NaN/Inf; weight load likely failed.",
+    )
 
     meta = {
         "variant": variant_l,
@@ -939,17 +936,7 @@ class DOFAEmbedder(EmbedderBase):
                 "patch_size": int(getattr(model, "patch_size", 16)),
             }
 
-            da = xr.DataArray(
-                grid,
-                dims=("d", "y", "x"),
-                coords={
-                    "d": np.arange(grid.shape[0]),
-                    "y": np.arange(grid.shape[1]),
-                    "x": np.arange(grid.shape[2]),
-                },
-                name="embedding",
-                attrs=meta,
-            )
+            da = grid_to_dataarray(grid, meta=meta)
             return Embedding(data=da, meta=meta)
 
         raise ModelError(f"Unknown output mode: {output.mode}")
@@ -1170,17 +1157,7 @@ class DOFAEmbedder(EmbedderBase):
                         "grid_hw_tokens": (int(grid.shape[1]), int(grid.shape[2])),
                         "patch_size": int(getattr(model, "patch_size", 16)),
                     }
-                    da = xr.DataArray(
-                        grid,
-                        dims=("d", "y", "x"),
-                        coords={
-                            "d": np.arange(grid.shape[0]),
-                            "y": np.arange(grid.shape[1]),
-                            "x": np.arange(grid.shape[2]),
-                        },
-                        name="embedding",
-                        attrs=meta,
-                    )
+                    da = grid_to_dataarray(grid, meta=meta)
                     out[i] = Embedding(data=da, meta=meta)
                     continue
 

--- a/src/rs_embed/embedders/onthefly_fomo.py
+++ b/src/rs_embed/embedders/onthefly_fomo.py
@@ -8,7 +8,6 @@ from functools import lru_cache
 from typing import Any
 
 import numpy as np
-import xarray as xr
 
 from ..core.embedding import Embedding
 from ..core.errors import ModelError
@@ -45,6 +44,7 @@ from ..tools.spatial import square_spatial
 from .base import EmbedderBase
 from .meta import build_meta, temporal_to_range
 from .onthefly_terramind import _fetch_s2_sr_12_raw_chw
+from .shared import grid_to_dataarray, normalize_s2, verify_loaded_params
 
 
 def ensure_torch() -> None:
@@ -309,16 +309,12 @@ def _load_fomo_cached(
 
     model = _move_model_to_device(model, dev, model_name="FoMo")
 
-    p0 = None
-    for _, p in model.named_parameters():
-        if p is not None and p.numel() > 0:
-            p0 = p.detach()
-            break
-    if p0 is None:
-        raise ModelError("FoMo model has no parameters; cannot verify loaded checkpoint.")
-    if not torch.isfinite(p0).all():
-        raise ModelError("FoMo model parameters contain NaN/Inf; checkpoint load likely failed.")
-    p0f = p0.float()
+    wstats = verify_loaded_params(
+        model,
+        model_name="FoMo",
+        no_params_msg="FoMo model has no parameters; cannot verify loaded checkpoint.",
+        nonfinite_msg="FoMo model parameters contain NaN/Inf; checkpoint load likely failed.",
+    )
 
     meta = {
         "ckpt_path": ckpt_path,
@@ -334,9 +330,7 @@ def _load_fomo_cached(
         "device": str(dev),
         "missing_keys": int(len(getattr(msg, "missing_keys", []))),
         "unexpected_keys": int(len(getattr(msg, "unexpected_keys", []))),
-        "param_mean": float(p0f.mean().cpu()),
-        "param_std": float(p0f.std().cpu()),
-        "param_absmax": float(p0f.abs().max().cpu()),
+        **wstats,
     }
     return model, meta
 
@@ -382,27 +376,12 @@ def _resize_chw(x_chw: np.ndarray, *, out_hw: int) -> np.ndarray:
 
 
 def _normalize_s2(raw_chw: np.ndarray, *, mode: str) -> np.ndarray:
-    x = np.asarray(raw_chw, dtype=np.float32)
-    x = np.nan_to_num(x, nan=0.0, posinf=0.0, neginf=0.0)
-    x = np.clip(x, 0.0, 10000.0)
-
-    m = str(mode).lower().strip()
-    if m in {"unit", "unit_scale", "reflectance"}:
-        x = x / 10000.0
-    elif m in {"per_tile_minmax", "minmax", "tile_minmax"}:
-        x = x / 10000.0
-        lo = np.min(x, axis=(1, 2), keepdims=True)
-        hi = np.max(x, axis=(1, 2), keepdims=True)
-        den = np.maximum(hi - lo, 1e-6)
-        x = (x - lo) / den
-    elif m in {"none", "raw"}:
-        pass
-    else:
-        raise ModelError(
-            f"Unknown FoMo normalization mode '{mode}'. "
-            "Use one of: unit_scale, per_tile_minmax, none."
-        )
-    return np.nan_to_num(x, nan=0.0, posinf=0.0, neginf=0.0).astype(np.float32)
+    return normalize_s2(
+        raw_chw,
+        mode=mode,
+        model_name="FoMo",
+        modes_hint="unit_scale, per_tile_minmax, none",
+    )
 
 
 def _resolve_s2_modality_keys() -> tuple[int, ...]:
@@ -737,17 +716,7 @@ class FoMoEmbedder(EmbedderBase):
                 "grid_shape": tuple(grid.shape),
                 "grid_hw": (int(grid.shape[1]), int(grid.shape[2])),
             }
-            da = xr.DataArray(
-                grid.astype(np.float32),
-                dims=("d", "y", "x"),
-                coords={
-                    "d": np.arange(grid.shape[0]),
-                    "y": np.arange(grid.shape[1]),
-                    "x": np.arange(grid.shape[2]),
-                },
-                name="embedding",
-                attrs=gmeta_full,
-            )
+            da = grid_to_dataarray(grid.astype(np.float32), meta=gmeta_full)
             return Embedding(data=da, meta=gmeta_full)
 
         raise ModelError(f"Unknown output mode: {output.mode}")
@@ -892,17 +861,7 @@ class FoMoEmbedder(EmbedderBase):
                     "grid_shape": tuple(grid.shape),
                     "grid_hw": (int(grid.shape[1]), int(grid.shape[2])),
                 }
-                da = xr.DataArray(
-                    grid.astype(np.float32),
-                    dims=("d", "y", "x"),
-                    coords={
-                        "d": np.arange(grid.shape[0]),
-                        "y": np.arange(grid.shape[1]),
-                        "x": np.arange(grid.shape[2]),
-                    },
-                    name="embedding",
-                    attrs=gmeta_full,
-                )
+                da = grid_to_dataarray(grid.astype(np.float32), meta=gmeta_full)
                 embeddings.append(Embedding(data=da, meta=gmeta_full))
             else:
                 raise ModelError(f"Unknown output mode: {output.mode}")

--- a/src/rs_embed/embedders/onthefly_galileo.py
+++ b/src/rs_embed/embedders/onthefly_galileo.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-import xarray as xr
 
 from ..core.embedding import Embedding
 from ..core.errors import ModelError
@@ -58,6 +57,7 @@ from ..tools.temporal import temporal_frame_midpoints
 from .base import EmbedderBase
 from .config import model_config_value
 from .meta import build_meta, temporal_to_range
+from .shared import grid_to_dataarray, normalize_s2, verify_loaded_params
 
 
 def ensure_torch() -> None:
@@ -225,33 +225,13 @@ def _resize_tchw(x_tchw: np.ndarray, *, out_hw: int) -> np.ndarray:
 
 
 def _normalize_s2(raw: np.ndarray, *, mode: str) -> np.ndarray:
-    x = np.asarray(raw, dtype=np.float32)
-    if x.ndim not in {3, 4}:
-        raise ModelError(f"Galileo normalization expects CHW or TCHW, got {x.shape}")
-    x = np.nan_to_num(x, nan=0.0, posinf=0.0, neginf=0.0)
-    x = np.clip(x, 0.0, 10000.0)
-
-    m = str(mode).lower().strip()
-    if m in {"unit", "unit_scale", "reflectance"}:
-        x = x / 10000.0
-    elif m in {"per_tile_minmax", "minmax", "tile_minmax"}:
-        x = x / 10000.0
-        if x.ndim == 3:
-            lo = np.min(x, axis=(1, 2), keepdims=True)
-            hi = np.max(x, axis=(1, 2), keepdims=True)
-        else:
-            lo = np.min(x, axis=(2, 3), keepdims=True)
-            hi = np.max(x, axis=(2, 3), keepdims=True)
-        den = np.maximum(hi - lo, 1e-6)
-        x = (x - lo) / den
-    elif m in {"none", "raw"}:
-        pass
-    else:
-        raise ModelError(
-            f"Unknown Galileo normalization mode '{mode}'. "
-            "Use one of: none, unit_scale, per_tile_minmax, official_stats."
-        )
-    return np.nan_to_num(x, nan=0.0, posinf=0.0, neginf=0.0).astype(np.float32)
+    return normalize_s2(
+        raw,
+        mode=mode,
+        model_name="Galileo",
+        modes_hint="none, unit_scale, per_tile_minmax, official_stats",
+        allow_tchw=True,
+    )
 
 
 def _apply_galileo_pretrain_stats(data: dict[str, Any]) -> None:
@@ -572,25 +552,18 @@ def _load_galileo_cached(
 
     encoder = _move_model_to_device(encoder, dev, model_name="Galileo")
 
-    p0 = None
-    for _, p in encoder.named_parameters():
-        if p is not None and p.numel() > 0:
-            p0 = p.detach()
-            break
-    if p0 is None:
-        raise ModelError("Galileo encoder has no parameters; cannot verify load.")
-    if not torch.isfinite(p0).all():
-        raise ModelError("Galileo parameters contain NaN/Inf; load likely failed.")
-    p0f = p0.float()
+    wstats = verify_loaded_params(
+        encoder,
+        model_name="Galileo",
+        no_params_msg="Galileo encoder has no parameters; cannot verify load.",
+    )
 
     meta = {
         "model_size": str(model_size),
         "model_root": model_root,
         "model_source": (model_root if model_path else f"hf://{hf_repo}/models/{model_size}"),
         "device": str(dev),
-        "param_mean": float(p0f.mean().cpu()),
-        "param_std": float(p0f.std().cpu()),
-        "param_absmax": float(p0f.abs().max().cpu()),
+        **wstats,
     }
     return encoder, meta, mod
 
@@ -1143,17 +1116,7 @@ class GalileoEmbedder(EmbedderBase):
                 "grid_shape": tuple(grid.shape),
                 "grid_hw": (int(grid.shape[1]), int(grid.shape[2])),
             }
-            da = xr.DataArray(
-                grid.astype(np.float32),
-                dims=("d", "y", "x"),
-                coords={
-                    "d": np.arange(grid.shape[0]),
-                    "y": np.arange(grid.shape[1]),
-                    "x": np.arange(grid.shape[2]),
-                },
-                name="embedding",
-                attrs=gmeta,
-            )
+            da = grid_to_dataarray(grid.astype(np.float32), meta=gmeta)
             return Embedding(data=da, meta=gmeta)
 
         raise ModelError(f"Unknown output mode: {output.mode}")

--- a/src/rs_embed/embedders/onthefly_olmoearth.py
+++ b/src/rs_embed/embedders/onthefly_olmoearth.py
@@ -45,6 +45,7 @@ from ..tools.spatial import FULL_WINDOW, square_spatial
 from .base import EmbedderBase
 from .config import model_config_value
 from .meta import build_meta, temporal_midpoint_str, temporal_to_range
+from .shared import grid_to_dataarray
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -1336,12 +1337,10 @@ class OlmoEarthEmbedder(EmbedderBase):
         for i, x in enumerate(prepared):
             shape_groups.setdefault(x.shape, []).append(i)
 
-        xr_mod = None
         if output.mode == "grid":
             try:
-                import xarray as xr  # noqa: PLC0415
-
-                xr_mod = xr
+                # fail fast before batch inference
+                import xarray  # noqa: F401, PLC0415
             except ImportError as exc:
                 raise ModelError(
                     "grid output requires xarray. Install: pip install xarray"
@@ -1458,14 +1457,7 @@ class OlmoEarthEmbedder(EmbedderBase):
                         )
                         d, h, w = grid_np.shape
                         meta.update({"grid_hw": (h, w), "grid_kind": "spatial_tokens"})
-                        assert xr_mod is not None
-                        da = xr_mod.DataArray(
-                            grid_np,
-                            dims=("d", "y", "x"),
-                            coords={"d": np.arange(d), "y": np.arange(h), "x": np.arange(w)},
-                            name="embedding",
-                            attrs=meta,
-                        )
+                        da = grid_to_dataarray(grid_np, meta=meta)
                         out[i] = Embedding(data=da, meta=meta)
                     continue
 
@@ -1559,7 +1551,7 @@ def _make_grid_embedding(
     roi_window: tuple[float, float, float, float] = _FULL_ROI,
 ) -> Embedding:
     try:
-        import xarray as xr  # noqa: PLC0415
+        import xarray  # noqa: F401, PLC0415
     except ImportError as exc:
         raise ModelError("grid output requires xarray. Install: pip install xarray") from exc
 
@@ -1567,11 +1559,5 @@ def _make_grid_embedding(
     grid = crop_grid_to_roi(grid, roi_window)  # crop padded border back to the ROI
     d, h, w = grid.shape
     meta.update({"grid_hw": (h, w), "grid_kind": "spatial_tokens"})
-    da = xr.DataArray(
-        grid,
-        dims=("d", "y", "x"),
-        coords={"d": np.arange(d), "y": np.arange(h), "x": np.arange(w)},
-        name="embedding",
-        attrs=meta,
-    )
+    da = grid_to_dataarray(grid, meta=meta)
     return Embedding(data=da, meta=meta)

--- a/src/rs_embed/embedders/onthefly_prithvi.py
+++ b/src/rs_embed/embedders/onthefly_prithvi.py
@@ -52,7 +52,8 @@ from ..tools.spatial import FULL_WINDOW, square_spatial
 from ..tools.temporal import temporal_frame_midpoints as _temporal_frame_midpoints
 from .base import EmbedderBase
 from .config import model_config_value
-from .meta import build_meta, temporal_midpoint_str, temporal_to_range
+from .meta import base_meta, temporal_midpoint_str, temporal_to_range
+from .shared import grid_to_dataarray, import_xarray, pool_from_tokens, tokens_to_grid_dhw
 
 
 def ensure_torch() -> None:
@@ -60,59 +61,6 @@ def ensure_torch() -> None:
         import torch  # noqa: F401
     except Exception as e:
         raise ModelError("This embedder requires torch installed.") from e
-
-
-def base_meta(
-    *,
-    model_name,
-    hf_id,
-    backend,
-    image_size,
-    sensor,
-    temporal=None,
-    source=None,
-    embed_type="on_the_fly",
-    extra=None,
-):
-    m = build_meta(
-        model=model_name,
-        kind=embed_type,
-        backend=backend,
-        source=source or getattr(sensor, "collection", None),
-        sensor=sensor,
-        temporal=temporal,
-        image_size=image_size,
-    )
-    m["hf_id"] = hf_id
-    if extra:
-        m.update(extra)
-    return m
-
-
-def pool_from_tokens(tokens, pooling):
-    n = len(tokens)
-    h2 = int((n - 1) ** 0.5)
-    has_cls = n > 1 and h2 * h2 == n - 1
-    patch = tokens[1:] if has_cls else tokens
-    if len(patch) == 0:
-        return tokens[0].astype("float32"), has_cls
-    if pooling == "mean":
-        return patch.mean(axis=0).astype("float32"), has_cls
-    if pooling == "max":
-        return patch.max(axis=0).astype("float32"), has_cls
-    raise ModelError(f"Unknown pooling={pooling!r} (expected 'mean' or 'max').")
-
-
-def tokens_to_grid_dhw(tokens):
-    n = len(tokens)
-    h2 = int((n - 1) ** 0.5)
-    has_cls = n > 1 and h2 * h2 == n - 1
-    patch = tokens[1:] if has_cls else tokens
-    p, d = patch.shape
-    hw = int(p**0.5)
-    if hw * hw != p:
-        raise ModelError(f"Patch token count {p} is not a perfect square.")
-    return patch.reshape(hw, hw, d).transpose(2, 0, 1).astype("float32"), (hw, hw), has_cls
 
 
 def _split_prithvi_patch_tokens(tokens, n_frames: int):
@@ -1352,22 +1300,7 @@ class PrithviEOV2S2_6B_Embedder(EmbedderBase):
                 }
             )
 
-            try:
-                import xarray as xr
-            except Exception as e:
-                raise ModelError("grid output requires xarray. Install: pip install xarray") from e
-
-            da = xr.DataArray(
-                grid,
-                dims=("d", "y", "x"),
-                coords={
-                    "d": np.arange(grid.shape[0]),
-                    "y": np.arange(h),
-                    "x": np.arange(w),
-                },
-                name="embedding",
-                attrs=meta,
-            )
+            da = grid_to_dataarray(grid, meta=meta)
             return Embedding(data=da, meta=meta)
 
         raise ModelError(f"Unknown output mode: {output.mode}")
@@ -1528,22 +1461,7 @@ class PrithviEOV2S2_6B_Embedder(EmbedderBase):
                     "cls_removed": bool(cls_removed),
                 }
             )
-            try:
-                import xarray as xr
-            except Exception as e:
-                raise ModelError("grid output requires xarray. Install: pip install xarray") from e
-
-            da = xr.DataArray(
-                grid,
-                dims=("d", "y", "x"),
-                coords={
-                    "d": np.arange(grid.shape[0]),
-                    "y": np.arange(h),
-                    "x": np.arange(w),
-                },
-                name="embedding",
-                attrs=meta,
-            )
+            da = grid_to_dataarray(grid, meta=meta)
             return Embedding(data=da, meta=meta)
 
         raise ModelError(f"Unknown output mode: {output.mode}")
@@ -1722,14 +1640,8 @@ class PrithviEOV2S2_6B_Embedder(EmbedderBase):
             shape_groups.setdefault(tuple(x.shape), []).append(i)
 
         out: list[Embedding | None] = [None] * len(spatials)
-        xr_mod = None
         if output.mode == "grid":
-            try:
-                import xarray as xr  # type: ignore
-
-                xr_mod = xr
-            except Exception as e:
-                raise ModelError("grid output requires xarray. Install: pip install xarray") from e
+            import_xarray()  # fail fast before batch inference
 
         for idxs in shape_groups.values():
             for s0 in range(0, len(idxs), infer_bs):
@@ -1811,18 +1723,7 @@ class PrithviEOV2S2_6B_Embedder(EmbedderBase):
                                 "cls_removed": bool(cls_removed),
                             }
                         )
-                        assert xr_mod is not None
-                        da = xr_mod.DataArray(
-                            grid,
-                            dims=("d", "y", "x"),
-                            coords={
-                                "d": np.arange(grid.shape[0]),
-                                "y": np.arange(h),
-                                "x": np.arange(w),
-                            },
-                            name="embedding",
-                            attrs=meta,
-                        )
+                        da = grid_to_dataarray(grid, meta=meta)
                         out[i] = Embedding(data=da, meta=meta)
                         continue
 
@@ -1895,14 +1796,8 @@ class PrithviEOV2S2_6B_Embedder(EmbedderBase):
         for i, x in enumerate(prepared):
             shape_groups.setdefault(tuple(x.shape), []).append(i)
 
-        xr_mod = None
         if output.mode == "grid":
-            try:
-                import xarray as xr  # type: ignore
-
-                xr_mod = xr
-            except Exception as e:
-                raise ModelError("grid output requires xarray. Install: pip install xarray") from e
+            import_xarray()  # fail fast before batch inference
 
         out: list[Embedding | None] = [None] * len(spatials)
         for idxs in shape_groups.values():
@@ -2011,18 +1906,7 @@ class PrithviEOV2S2_6B_Embedder(EmbedderBase):
                                 "cls_removed": bool(cls_removed),
                             }
                         )
-                        assert xr_mod is not None
-                        da = xr_mod.DataArray(
-                            grid,
-                            dims=("d", "y", "x"),
-                            coords={
-                                "d": np.arange(grid.shape[0]),
-                                "y": np.arange(h),
-                                "x": np.arange(w),
-                            },
-                            name="embedding",
-                            attrs=meta,
-                        )
+                        da = grid_to_dataarray(grid, meta=meta)
                         out[i] = Embedding(data=da, meta=meta)
                         continue
 

--- a/src/rs_embed/embedders/onthefly_remoteclip.py
+++ b/src/rs_embed/embedders/onthefly_remoteclip.py
@@ -8,7 +8,6 @@ from functools import lru_cache
 from typing import Any
 
 import numpy as np
-import xarray as xr
 
 from ..core.embedding import Embedding
 from ..core.errors import ModelError
@@ -48,6 +47,7 @@ from ..tools.spatial import square_spatial
 from .base import EmbedderBase
 from .config import model_config_value
 from .meta import build_meta, temporal_to_range
+from .shared import grid_to_dataarray, resolve_hf_cache_dir, verify_loaded_params
 
 _DEFAULT_REMOTECLIP_ID = "MVRL/remote-clip-vit-base-patch32"
 
@@ -176,26 +176,8 @@ def _ensure_hf_weights(
 
 def _assert_weights_loaded(model) -> dict[str, float]:
     """Best-effort sanity check that weights are loaded (do not trust rshf warnings)."""
-    import torch
-
     core = getattr(model, "model", model)
-    p = None
-    for _, param in core.named_parameters():
-        if param is not None and param.numel() > 0:
-            p = param.detach()
-            break
-    if p is None:
-        raise ModelError("RemoteCLIP model has no parameters; cannot verify weights.")
-    if not torch.isfinite(p).all():
-        raise ModelError("RemoteCLIP parameters contain NaN/Inf; load likely failed.")
-
-    p_f = p.float()
-    std = float(p_f.std().cpu())
-    mx = float(p_f.abs().max().cpu())
-    mean = float(p_f.mean().cpu())
-    if std < 1e-6 and mx < 1e-5:
-        raise ModelError("RemoteCLIP parameters look uninitialized (near-zero stats).")
-    return {"param_mean": mean, "param_std": std, "param_absmax": mx}
+    return verify_loaded_params(core, model_name="RemoteCLIP", check_near_zero=True)
 
 
 @contextmanager
@@ -779,11 +761,7 @@ class RemoteCLIPS2RGBEmbedder(EmbedderBase):
         rgb_u8 = _s2_rgb_u8_from_chw(s2_rgb_chw)
 
         # HF cache dir
-        cache_dir = (
-            os.environ.get("HUGGINGFACE_HUB_CACHE")
-            or os.environ.get("HF_HOME")
-            or os.environ.get("HUGGINGFACE_HOME")
-        )
+        cache_dir = resolve_hf_cache_dir()
 
         # load model once per (ckpt, cache_dir, device)
         model, wmeta, dev = self._get_model(ckpt=ckpt, cache_dir=cache_dir, device=device)
@@ -877,17 +855,7 @@ class RemoteCLIPS2RGBEmbedder(EmbedderBase):
                 "grid_type": "vit_tokens",
             }  # patch grid, not pixel grid
 
-            da = xr.DataArray(
-                grid_dhw,
-                dims=("d", "y", "x"),
-                coords={
-                    "d": np.arange(grid_dhw.shape[0]),
-                    "y": np.arange(grid_dhw.shape[1]),
-                    "x": np.arange(grid_dhw.shape[2]),
-                },
-                name="embedding",
-                attrs=meta,
-            )
+            da = grid_to_dataarray(grid_dhw, meta=meta)
             return Embedding(data=da, meta=meta)
 
         raise ModelError(f"Unknown output mode: {output.mode}")
@@ -980,11 +948,7 @@ class RemoteCLIPS2RGBEmbedder(EmbedderBase):
 
         ckpt = _resolve_remoteclip_model_id(model_config, sensor)
 
-        cache_dir = (
-            os.environ.get("HUGGINGFACE_HUB_CACHE")
-            or os.environ.get("HF_HOME")
-            or os.environ.get("HUGGINGFACE_HOME")
-        )
+        cache_dir = resolve_hf_cache_dir()
         model, wmeta, dev = self._get_model(ckpt=ckpt, cache_dir=cache_dir, device=device)
         infer_bs = self._resolve_infer_batch(str(dev))
 
@@ -1098,17 +1062,7 @@ class RemoteCLIPS2RGBEmbedder(EmbedderBase):
                 meta = _base_meta_for(
                     {**tmeta, **gmeta, "batch_infer": False, "grid_type": "vit_tokens"}
                 )
-                da = xr.DataArray(
-                    grid_dhw,
-                    dims=("d", "y", "x"),
-                    coords={
-                        "d": np.arange(grid_dhw.shape[0]),
-                        "y": np.arange(grid_dhw.shape[1]),
-                        "x": np.arange(grid_dhw.shape[2]),
-                    },
-                    name="embedding",
-                    attrs=meta,
-                )
+                da = grid_to_dataarray(grid_dhw, meta=meta)
                 out[i] = Embedding(data=da, meta=meta)
         else:
             raise ModelError(f"Unknown output mode: {output.mode}")

--- a/src/rs_embed/embedders/onthefly_satmae.py
+++ b/src/rs_embed/embedders/onthefly_satmae.py
@@ -34,7 +34,8 @@ from ..tools.shape import (
 )
 from ..tools.spatial import square_spatial
 from .base import EmbedderBase
-from .meta import build_meta, temporal_to_range
+from .meta import base_meta, temporal_to_range
+from .shared import grid_to_dataarray, pool_from_tokens, tokens_to_grid_dhw
 
 
 def ensure_torch() -> None:
@@ -138,59 +139,6 @@ def _satmae_preprocess_tensor_batch(model, rgb_u8_batch: list[np.ndarray], *, im
     return torch.stack(xs, dim=0)
 
 
-def base_meta(
-    *,
-    model_name,
-    hf_id,
-    backend,
-    image_size,
-    sensor,
-    temporal=None,
-    source=None,
-    embed_type="on_the_fly",
-    extra=None,
-):
-    m = build_meta(
-        model=model_name,
-        kind=embed_type,
-        backend=backend,
-        source=source or getattr(sensor, "collection", None),
-        sensor=sensor,
-        temporal=temporal,
-        image_size=image_size,
-    )
-    m["hf_id"] = hf_id
-    if extra:
-        m.update(extra)
-    return m
-
-
-def pool_from_tokens(tokens, pooling):
-    n = len(tokens)
-    h2 = int((n - 1) ** 0.5)
-    has_cls = n > 1 and h2 * h2 == n - 1
-    patch = tokens[1:] if has_cls else tokens
-    if len(patch) == 0:
-        return tokens[0].astype("float32"), has_cls
-    if pooling == "mean":
-        return patch.mean(axis=0).astype("float32"), has_cls
-    if pooling == "max":
-        return patch.max(axis=0).astype("float32"), has_cls
-    raise ModelError(f"Unknown pooling={pooling!r} (expected 'mean' or 'max').")
-
-
-def tokens_to_grid_dhw(tokens):
-    n = len(tokens)
-    h2 = int((n - 1) ** 0.5)
-    has_cls = n > 1 and h2 * h2 == n - 1
-    patch = tokens[1:] if has_cls else tokens
-    p, d = patch.shape
-    hw = int(p**0.5)
-    if hw * hw != p:
-        raise ModelError(f"Patch token count {p} is not a perfect square.")
-    return patch.reshape(hw, hw, d).transpose(2, 0, 1).astype("float32"), (hw, hw), has_cls
-
-
 def build_token_embedding(tokens, *, geo_roi, output, meta):
     """Turn ``[N,D]`` tokens into an Embedding, cropping the patch grid to the ROI.
 
@@ -223,17 +171,7 @@ def build_token_embedding(tokens, *, geo_roi, output, meta):
         meta.update(
             {"grid_hw": (h, w), "grid_kind": "patch_tokens", "cls_removed": bool(cls_removed)}
         )
-        try:
-            import xarray as xr
-        except Exception as e:
-            raise ModelError("grid output requires xarray. Install: pip install xarray") from e
-        da = xr.DataArray(
-            grid,
-            dims=("d", "y", "x"),
-            coords={"d": np.arange(grid.shape[0]), "y": np.arange(h), "x": np.arange(w)},
-            name="embedding",
-            attrs=meta,
-        )
+        da = grid_to_dataarray(grid, meta=meta)
         return Embedding(data=da, meta=meta)
 
     raise ModelError(f"Unknown output mode: {output.mode}")

--- a/src/rs_embed/embedders/onthefly_satmaepp.py
+++ b/src/rs_embed/embedders/onthefly_satmaepp.py
@@ -36,10 +36,11 @@ from ..tools.shape import (
 )
 from ..tools.spatial import square_spatial
 from .base import EmbedderBase
-from .meta import build_meta, temporal_to_range
+from .meta import base_meta, temporal_to_range
 from .onthefly_satmaepp_s2 import (
     SatMAEPPSentinel10Embedder,
 )
+from .shared import grid_to_dataarray, pool_from_tokens, tokens_to_grid_dhw
 
 
 def ensure_torch() -> None:
@@ -67,59 +68,6 @@ def fetch_s2_rgb_u8_from_provider(provider, *, spatial, temporal, sensor, out_si
 
     im = Image.fromarray(rgb_u8, mode="RGB")
     return np.array(im.resize((out_size, out_size), resample=Image.BICUBIC), dtype=np.uint8)
-
-
-def base_meta(
-    *,
-    model_name,
-    hf_id,
-    backend,
-    image_size,
-    sensor,
-    temporal=None,
-    source=None,
-    embed_type="on_the_fly",
-    extra=None,
-):
-    m = build_meta(
-        model=model_name,
-        kind=embed_type,
-        backend=backend,
-        source=source or getattr(sensor, "collection", None),
-        sensor=sensor,
-        temporal=temporal,
-        image_size=image_size,
-    )
-    m["hf_id"] = hf_id
-    if extra:
-        m.update(extra)
-    return m
-
-
-def pool_from_tokens(tokens, pooling):
-    n = len(tokens)
-    h2 = int((n - 1) ** 0.5)
-    has_cls = n > 1 and h2 * h2 == n - 1
-    patch = tokens[1:] if has_cls else tokens
-    if len(patch) == 0:
-        return tokens[0].astype("float32"), has_cls
-    if pooling == "mean":
-        return patch.mean(axis=0).astype("float32"), has_cls
-    if pooling == "max":
-        return patch.max(axis=0).astype("float32"), has_cls
-    raise ModelError(f"Unknown pooling={pooling!r} (expected 'mean' or 'max').")
-
-
-def tokens_to_grid_dhw(tokens):
-    n = len(tokens)
-    h2 = int((n - 1) ** 0.5)
-    has_cls = n > 1 and h2 * h2 == n - 1
-    patch = tokens[1:] if has_cls else tokens
-    p, d = patch.shape
-    hw = int(p**0.5)
-    if hw * hw != p:
-        raise ModelError(f"Patch token count {p} is not a perfect square.")
-    return patch.reshape(hw, hw, d).transpose(2, 0, 1).astype("float32"), (hw, hw), has_cls
 
 
 def build_token_embedding(tokens, *, geo_roi, output, meta):
@@ -154,17 +102,7 @@ def build_token_embedding(tokens, *, geo_roi, output, meta):
         meta.update(
             {"grid_hw": (h, w), "grid_kind": "patch_tokens", "cls_removed": bool(cls_removed)}
         )
-        try:
-            import xarray as xr
-        except Exception as e:
-            raise ModelError("grid output requires xarray. Install: pip install xarray") from e
-        da = xr.DataArray(
-            grid,
-            dims=("d", "y", "x"),
-            coords={"d": np.arange(grid.shape[0]), "y": np.arange(h), "x": np.arange(w)},
-            name="embedding",
-            attrs=meta,
-        )
+        da = grid_to_dataarray(grid, meta=meta)
         return Embedding(data=da, meta=meta)
 
     raise ModelError(f"Unknown output mode: {output.mode}")

--- a/src/rs_embed/embedders/onthefly_satmaepp_s2.py
+++ b/src/rs_embed/embedders/onthefly_satmaepp_s2.py
@@ -40,7 +40,8 @@ from ..tools.shape import (
 from ..tools.spatial import square_spatial
 from .base import EmbedderBase
 from .config import model_config_value
-from .meta import build_meta, temporal_to_range
+from .meta import base_meta, temporal_to_range
+from .shared import grid_to_dataarray, import_xarray, resolve_hf_cache_dir, verify_loaded_params
 
 
 def ensure_torch() -> None:
@@ -48,33 +49,6 @@ def ensure_torch() -> None:
         import torch  # noqa: F401
     except Exception as e:
         raise ModelError("This embedder requires torch installed.") from e
-
-
-def base_meta(
-    *,
-    model_name,
-    hf_id,
-    backend,
-    image_size,
-    sensor,
-    temporal=None,
-    source=None,
-    embed_type="on_the_fly",
-    extra=None,
-):
-    m = build_meta(
-        model=model_name,
-        kind=embed_type,
-        backend=backend,
-        source=source or getattr(sensor, "collection", None),
-        sensor=sensor,
-        temporal=temporal,
-        image_size=image_size,
-    )
-    m["hf_id"] = hf_id
-    if extra:
-        m.update(extra)
-    return m
 
 
 # SatMAE++ Sentinel branch in source repo drops [B1, B9, B10] and uses 10 channels.
@@ -239,11 +213,7 @@ def _torch_load_checkpoint_compat(path: str):
 
 
 def _resolve_hf_cache_dir() -> str | None:
-    d = (
-        os.environ.get("HUGGINGFACE_HUB_CACHE")
-        or os.environ.get("HF_HOME")
-        or os.environ.get("HUGGINGFACE_HOME")
-    )
+    d = resolve_hf_cache_dir()
     return str(d) if d else None
 
 
@@ -300,7 +270,6 @@ def _load_satmaepp_s2_cached(
     cache_dir: str | None,
 ):
     ensure_torch()
-    import torch
 
     ckpt_path = _ensure_satmaepp_s2_assets(
         ckpt_repo=ckpt_repo,
@@ -345,15 +314,12 @@ def _load_satmaepp_s2_cached(
 
     model = _move_model_to_device(model, dev, model_name="SatMAE++ Sentinel-2")
 
-    p0 = None
-    for _, p in model.named_parameters():
-        if p is not None and p.numel() > 0:
-            p0 = p.detach()
-            break
-    if p0 is None:
-        raise ModelError("SatMAE++ Sentinel model has no parameters; checkpoint load failed.")
-    if not torch.isfinite(p0).all():
-        raise ModelError("SatMAE++ Sentinel parameters contain NaN/Inf; checkpoint likely invalid.")
+    wstats = verify_loaded_params(
+        model,
+        model_name="SatMAE++ Sentinel",
+        no_params_msg="SatMAE++ Sentinel model has no parameters; checkpoint load failed.",
+        nonfinite_msg="SatMAE++ Sentinel parameters contain NaN/Inf; checkpoint likely invalid.",
+    )
 
     meta = {
         "device": str(dev),
@@ -365,9 +331,7 @@ def _load_satmaepp_s2_cached(
         "patch_size": int(patch_size),
         "in_chans": len(_S2_SR_10_BANDS),
         "channel_groups": tuple(tuple(int(i) for i in g) for g in _S2_10_CHANNEL_GROUPS),
-        "param_mean": float(p0.float().mean().cpu()),
-        "param_std": float(p0.float().std().cpu()),
-        "param_absmax": float(p0.float().abs().max().cpu()),
+        **wstats,
         "torch_weights_only": bool(_env_bool("RS_EMBED_SATMAEPP_S2_WEIGHTS_ONLY", False)),
     }
     return model, meta
@@ -847,22 +811,7 @@ class SatMAEPPSentinel10Embedder(EmbedderBase):
                 }
             )
 
-            try:
-                import xarray as xr
-            except Exception as e:
-                raise ModelError("grid output requires xarray. Install: pip install xarray") from e
-
-            da = xr.DataArray(
-                grid,
-                dims=("d", "y", "x"),
-                coords={
-                    "d": np.arange(grid.shape[0]),
-                    "y": np.arange(h),
-                    "x": np.arange(w),
-                },
-                name="embedding",
-                attrs=meta,
-            )
+            da = grid_to_dataarray(grid, meta=meta)
             return Embedding(data=da, meta=meta)
 
         raise ModelError(f"Unknown output mode: {output.mode}")
@@ -941,17 +890,11 @@ class SatMAEPPSentinel10Embedder(EmbedderBase):
         out: list[Embedding | None] = [None] * n
         want_grid = output.mode == "grid"
         any_cropped = any(not roi_is_full(gr) for gr in geo_rois)
-        xr_mod = None
         # group_reduce is needed for grid output, and also for pooled output when an
         # ROI was enlarged to a square (pooled then derives from the cropped grid).
         group_reduce = self._resolve_group_reduce() if (want_grid or any_cropped) else "mean"
         if want_grid:
-            try:
-                import xarray as xr  # type: ignore
-
-                xr_mod = xr
-            except Exception as e:
-                raise ModelError("grid output requires xarray. Install: pip install xarray") from e
+            import_xarray()  # fail fast before batch inference
 
         for s0 in range(0, n, infer_bs):
             s1 = min(n, s0 + infer_bs)
@@ -1014,7 +957,6 @@ class SatMAEPPSentinel10Embedder(EmbedderBase):
                         )
                     out[i] = Embedding(data=vec.astype(np.float32), meta=meta)
                 elif output.mode == "grid":
-                    assert xr_mod is not None
                     grid, (h, w), cls_removed, gmeta = _satmaepp_s2_grid(
                         tokens, group_reduce=group_reduce
                     )
@@ -1029,17 +971,7 @@ class SatMAEPPSentinel10Embedder(EmbedderBase):
                             **gmeta,
                         }
                     )
-                    da = xr_mod.DataArray(
-                        grid,
-                        dims=("d", "y", "x"),
-                        coords={
-                            "d": np.arange(grid.shape[0]),
-                            "y": np.arange(h),
-                            "x": np.arange(w),
-                        },
-                        name="embedding",
-                        attrs=meta,
-                    )
+                    da = grid_to_dataarray(grid, meta=meta)
                     out[i] = Embedding(data=da, meta=meta)
                 else:
                     raise ModelError(f"Unknown output mode: {output.mode}")
@@ -1129,17 +1061,11 @@ class SatMAEPPSentinel10Embedder(EmbedderBase):
         out: list[Embedding | None] = [None] * len(spatials)
         want_grid = output.mode == "grid"
         any_cropped = any(not roi_is_full(gr) for gr in geo_rois)
-        xr_mod = None
         # group_reduce is needed for grid output, and also for pooled output when an
         # ROI was enlarged to a square (pooled then derives from the cropped grid).
         group_reduce = self._resolve_group_reduce() if (want_grid or any_cropped) else "mean"
         if want_grid:
-            try:
-                import xarray as xr  # type: ignore
-
-                xr_mod = xr
-            except Exception as e:
-                raise ModelError("grid output requires xarray. Install: pip install xarray") from e
+            import_xarray()  # fail fast before batch inference
 
         n = len(spatials)
         for s0 in range(0, n, infer_bs):
@@ -1204,7 +1130,6 @@ class SatMAEPPSentinel10Embedder(EmbedderBase):
                         )
                     out[i] = Embedding(data=vec.astype(np.float32), meta=meta)
                 elif output.mode == "grid":
-                    assert xr_mod is not None
                     grid, (h, w), cls_removed, gmeta = _satmaepp_s2_grid(
                         tokens, group_reduce=group_reduce
                     )
@@ -1219,17 +1144,7 @@ class SatMAEPPSentinel10Embedder(EmbedderBase):
                             **gmeta,
                         }
                     )
-                    da = xr_mod.DataArray(
-                        grid,
-                        dims=("d", "y", "x"),
-                        coords={
-                            "d": np.arange(grid.shape[0]),
-                            "y": np.arange(h),
-                            "x": np.arange(w),
-                        },
-                        name="embedding",
-                        attrs=meta,
-                    )
+                    da = grid_to_dataarray(grid, meta=meta)
                     out[i] = Embedding(data=da, meta=meta)
                 else:
                     raise ModelError(f"Unknown output mode: {output.mode}")

--- a/src/rs_embed/embedders/onthefly_satvision_toa.py
+++ b/src/rs_embed/embedders/onthefly_satvision_toa.py
@@ -44,7 +44,8 @@ from ..tools.shape import (
 )
 from ..tools.spatial import FULL_WINDOW, square_spatial
 from .base import EmbedderBase
-from .meta import build_meta, temporal_to_range
+from .meta import base_meta, temporal_to_range
+from .shared import grid_to_dataarray, pool_from_tokens, tokens_to_grid_dhw, verify_loaded_params
 
 
 def ensure_torch() -> None:
@@ -52,59 +53,6 @@ def ensure_torch() -> None:
         import torch  # noqa: F401
     except Exception as e:
         raise ModelError("This embedder requires torch installed.") from e
-
-
-def base_meta(
-    *,
-    model_name,
-    hf_id,
-    backend,
-    image_size,
-    sensor,
-    temporal=None,
-    source=None,
-    embed_type="on_the_fly",
-    extra=None,
-):
-    m = build_meta(
-        model=model_name,
-        kind=embed_type,
-        backend=backend,
-        source=source or getattr(sensor, "collection", None),
-        sensor=sensor,
-        temporal=temporal,
-        image_size=image_size,
-    )
-    m["hf_id"] = hf_id
-    if extra:
-        m.update(extra)
-    return m
-
-
-def pool_from_tokens(tokens, pooling):
-    n = len(tokens)
-    h2 = int((n - 1) ** 0.5)
-    has_cls = n > 1 and h2 * h2 == n - 1
-    patch = tokens[1:] if has_cls else tokens
-    if len(patch) == 0:
-        return tokens[0].astype("float32"), has_cls
-    if pooling == "mean":
-        return patch.mean(axis=0).astype("float32"), has_cls
-    if pooling == "max":
-        return patch.max(axis=0).astype("float32"), has_cls
-    raise ModelError(f"Unknown pooling={pooling!r} (expected 'mean' or 'max').")
-
-
-def tokens_to_grid_dhw(tokens):
-    n = len(tokens)
-    h2 = int((n - 1) ** 0.5)
-    has_cls = n > 1 and h2 * h2 == n - 1
-    patch = tokens[1:] if has_cls else tokens
-    p, d = patch.shape
-    hw = int(p**0.5)
-    if hw * hw != p:
-        raise ModelError(f"Patch token count {p} is not a perfect square.")
-    return patch.reshape(hw, hw, d).transpose(2, 0, 1).astype("float32"), (hw, hw), has_cls
 
 
 def build_satvision_embedding(out_arr, *, geo_roi, output, meta):
@@ -162,17 +110,7 @@ def build_satvision_embedding(out_arr, *, geo_roi, output, meta):
                 "cls_removed": bool(cls_removed),
             }
         )
-        try:
-            import xarray as xr
-        except Exception as e:
-            raise ModelError("grid output requires xarray. Install: pip install xarray") from e
-        da = xr.DataArray(
-            grid,
-            dims=("d", "y", "x"),
-            coords={"d": np.arange(grid.shape[0]), "y": np.arange(h), "x": np.arange(w)},
-            name="embedding",
-            attrs=meta,
-        )
+        da = grid_to_dataarray(grid, meta=meta)
         return Embedding(data=da, meta=meta)
 
     raise ModelError(f"Unknown output mode: {output.mode}")
@@ -777,26 +715,19 @@ def _load_satvision_toa_cached(
 
     model = _move_model_to_device(model, dev, model_name="SatVision-TOA")
 
-    p0 = None
-    for _, p in model.named_parameters():
-        if p is not None and p.numel() > 0:
-            p0 = p.detach()
-            break
-    if p0 is None:
-        raise ModelError("SatVision-TOA model has no parameters after load.")
-    if not torch.isfinite(p0).all():
-        raise ModelError("SatVision-TOA parameters contain NaN/Inf after checkpoint load.")
-
-    p0f = p0.float()
+    wstats = verify_loaded_params(
+        model,
+        model_name="SatVision-TOA",
+        no_params_msg="SatVision-TOA model has no parameters after load.",
+        nonfinite_msg="SatVision-TOA parameters contain NaN/Inf after checkpoint load.",
+    )
     meta = {
         "checkpoint": ckpt_file,
         "device": dev,
         "matched_keys": int(matched),
         "missing_keys": int(len(missing)),
         "unexpected_keys": int(len(unexpected)),
-        "param_mean": float(p0f.mean().cpu()),
-        "param_std": float(p0f.std().cpu()),
-        "param_absmax": float(p0f.abs().max().cpu()),
+        **wstats,
         "model_impl": "vendored_official",
         "drop_path_rate": float(drop_path_rate),
         "pretrained_window_sizes": tuple(int(v) for v in pretrained_window_sizes),

--- a/src/rs_embed/embedders/onthefly_scalemae.py
+++ b/src/rs_embed/embedders/onthefly_scalemae.py
@@ -34,7 +34,8 @@ from ..tools.shape import (
 )
 from ..tools.spatial import square_spatial
 from .base import EmbedderBase
-from .meta import build_meta, temporal_to_range
+from .meta import base_meta, temporal_to_range
+from .shared import grid_to_dataarray, pool_from_tokens, tokens_to_grid_dhw
 
 
 def ensure_torch() -> None:
@@ -62,59 +63,6 @@ def fetch_s2_rgb_u8_from_provider(provider, *, spatial, temporal, sensor, out_si
 
     im = Image.fromarray(rgb_u8, mode="RGB")
     return np.array(im.resize((out_size, out_size), resample=Image.BICUBIC), dtype=np.uint8)
-
-
-def base_meta(
-    *,
-    model_name,
-    hf_id,
-    backend,
-    image_size,
-    sensor,
-    temporal=None,
-    source=None,
-    embed_type="on_the_fly",
-    extra=None,
-):
-    m = build_meta(
-        model=model_name,
-        kind=embed_type,
-        backend=backend,
-        source=source or getattr(sensor, "collection", None),
-        sensor=sensor,
-        temporal=temporal,
-        image_size=image_size,
-    )
-    m["hf_id"] = hf_id
-    if extra:
-        m.update(extra)
-    return m
-
-
-def pool_from_tokens(tokens, pooling):
-    n = len(tokens)
-    h2 = int((n - 1) ** 0.5)
-    has_cls = n > 1 and h2 * h2 == n - 1
-    patch = tokens[1:] if has_cls else tokens
-    if len(patch) == 0:
-        return tokens[0].astype("float32"), has_cls
-    if pooling == "mean":
-        return patch.mean(axis=0).astype("float32"), has_cls
-    if pooling == "max":
-        return patch.max(axis=0).astype("float32"), has_cls
-    raise ModelError(f"Unknown pooling={pooling!r} (expected 'mean' or 'max').")
-
-
-def tokens_to_grid_dhw(tokens):
-    n = len(tokens)
-    h2 = int((n - 1) ** 0.5)
-    has_cls = n > 1 and h2 * h2 == n - 1
-    patch = tokens[1:] if has_cls else tokens
-    p, d = patch.shape
-    hw = int(p**0.5)
-    if hw * hw != p:
-        raise ModelError(f"Patch token count {p} is not a perfect square.")
-    return patch.reshape(hw, hw, d).transpose(2, 0, 1).astype("float32"), (hw, hw), has_cls
 
 
 def build_scalemae_embedding(out, *, geo_roi, output, meta):
@@ -180,22 +128,7 @@ def build_scalemae_embedding(out, *, geo_roi, output, meta):
             }
         )
 
-        try:
-            import xarray as xr
-        except Exception as e:
-            raise ModelError("grid output requires xarray. Install: pip install xarray") from e
-
-        da = xr.DataArray(
-            grid,
-            dims=("d", "y", "x"),
-            coords={
-                "d": np.arange(grid.shape[0]),
-                "y": np.arange(h),
-                "x": np.arange(w),
-            },
-            name="embedding",
-            attrs=meta,
-        )
+        da = grid_to_dataarray(grid, meta=meta)
         return Embedding(data=da, meta=meta)
 
     raise ModelError(f"Unknown output mode: {output.mode}")

--- a/src/rs_embed/embedders/onthefly_terrafm.py
+++ b/src/rs_embed/embedders/onthefly_terrafm.py
@@ -8,7 +8,6 @@ from functools import lru_cache
 from typing import Any
 
 import numpy as np
-import xarray as xr
 
 from ..core.embedding import Embedding
 from ..core.errors import ModelError
@@ -51,6 +50,7 @@ from ..tools.spatial import FULL_WINDOW, square_spatial
 from .base import EmbedderBase
 from .config import model_config_value
 from .meta import build_meta, temporal_to_range
+from .shared import grid_to_dataarray, resolve_hf_cache_dir, verify_loaded_params
 
 HF_REPO_ID = "MBZUAI/TerraFM"
 HF_WEIGHT_FILE_B = "TerraFM-B.pth"
@@ -66,11 +66,7 @@ def _resolve_terrafm_cache_dir(model_config: dict[str, Any] | None) -> str | Non
     v = model_config_value(model_config, "cache_dir")
     if v is not None and str(v).strip():
         return str(v).strip()
-    return (
-        os.environ.get("HUGGINGFACE_HUB_CACHE")
-        or os.environ.get("HF_HOME")
-        or os.environ.get("HUGGINGFACE_HOME")
-    )
+    return resolve_hf_cache_dir()
 
 
 # -----------------------------
@@ -283,25 +279,7 @@ def _load_terrafm_module():
 
 def _assert_weights_loaded(model) -> dict[str, float]:
     """Same philosophy as your RemoteCLIP: param stats should not be near-zero."""
-    import torch
-
-    p = None
-    for _, param in model.named_parameters():
-        if param is not None and param.numel() > 0:
-            p = param.detach()
-            break
-    if p is None:
-        raise ModelError("TerraFM model has no parameters; cannot verify weights.")
-    if not torch.isfinite(p).all():
-        raise ModelError("TerraFM parameters contain NaN/Inf; load likely failed.")
-
-    p_f = p.float()
-    std = float(p_f.std().cpu())
-    mx = float(p_f.abs().max().cpu())
-    mean = float(p_f.mean().cpu())
-    if std < 1e-6 and mx < 1e-5:
-        raise ModelError("TerraFM parameters look uninitialized (near-zero stats).")
-    return {"param_mean": mean, "param_std": std, "param_absmax": mx}
+    return verify_loaded_params(model, model_name="TerraFM", check_near_zero=True)
 
 
 @lru_cache(maxsize=4)
@@ -840,17 +818,7 @@ class TerraFMBEmbedder(EmbedderBase):
                 "grid_type": "feature_map",
                 "grid_shape": tuple(grid.shape),
             }
-            da = xr.DataArray(
-                grid,
-                dims=("d", "y", "x"),
-                coords={
-                    "d": np.arange(grid.shape[0]),
-                    "y": np.arange(grid.shape[1]),
-                    "x": np.arange(grid.shape[2]),
-                },
-                name="embedding",
-                attrs=meta,
-            )
+            da = grid_to_dataarray(grid, meta=meta)
             return Embedding(data=da, meta=meta)
 
         raise ModelError(f"Unknown output mode: {output.mode}")
@@ -1138,17 +1106,7 @@ class TerraFMBEmbedder(EmbedderBase):
                         "grid_type": "feature_map",
                         "grid_shape": tuple(grid.shape),
                     }
-                    da = xr.DataArray(
-                        grid,
-                        dims=("d", "y", "x"),
-                        coords={
-                            "d": np.arange(grid.shape[0]),
-                            "y": np.arange(grid.shape[1]),
-                            "x": np.arange(grid.shape[2]),
-                        },
-                        name="embedding",
-                        attrs=meta,
-                    )
+                    da = grid_to_dataarray(grid, meta=meta)
                     out[i] = Embedding(data=da, meta=meta)
                     continue
 

--- a/src/rs_embed/embedders/onthefly_terramind.py
+++ b/src/rs_embed/embedders/onthefly_terramind.py
@@ -6,7 +6,6 @@ from functools import lru_cache
 from typing import Any
 
 import numpy as np
-import xarray as xr
 
 from ..core.embedding import Embedding
 from ..core.errors import ModelError
@@ -45,6 +44,7 @@ from ..tools.spatial import square_spatial
 from .base import EmbedderBase
 from .config import model_config_value
 from .meta import build_meta, temporal_to_range
+from .shared import grid_to_dataarray, pool_from_tokens, tokens_to_grid_dhw, verify_loaded_params
 
 
 def ensure_torch() -> None:
@@ -52,32 +52,6 @@ def ensure_torch() -> None:
         import torch  # noqa: F401
     except Exception as e:
         raise ModelError("This embedder requires torch installed.") from e
-
-
-def pool_from_tokens(tokens, pooling):
-    n = len(tokens)
-    h2 = int((n - 1) ** 0.5)
-    has_cls = n > 1 and h2 * h2 == n - 1
-    patch = tokens[1:] if has_cls else tokens
-    if len(patch) == 0:
-        return tokens[0].astype("float32"), has_cls
-    if pooling == "mean":
-        return patch.mean(axis=0).astype("float32"), has_cls
-    if pooling == "max":
-        return patch.max(axis=0).astype("float32"), has_cls
-    raise ModelError(f"Unknown pooling={pooling!r} (expected 'mean' or 'max').")
-
-
-def tokens_to_grid_dhw(tokens):
-    n = len(tokens)
-    h2 = int((n - 1) ** 0.5)
-    has_cls = n > 1 and h2 * h2 == n - 1
-    patch = tokens[1:] if has_cls else tokens
-    p, d = patch.shape
-    hw = int(p**0.5)
-    if hw * hw != p:
-        raise ModelError(f"Patch token count {p} is not a perfect square.")
-    return patch.reshape(hw, hw, d).transpose(2, 0, 1).astype("float32"), (hw, hw), has_cls
 
 
 _S2_SR_12_BANDS = [
@@ -337,7 +311,6 @@ def _load_terramind_cached(
     dev: str,
 ) -> tuple[Any, dict[str, Any]]:
     ensure_torch()
-    import torch
 
     BACKBONE_REGISTRY = _import_terramind_backbone_registry()
     _ensure_terramind_backbone_registered(BACKBONE_REGISTRY, model_key=str(model_key))
@@ -362,25 +335,14 @@ def _load_terramind_cached(
 
     model = _move_model_to_device(model, dev, model_name="TerraMind")
 
-    p0 = None
-    for _, p in model.named_parameters():
-        if p is not None and p.numel() > 0:
-            p0 = p.detach()
-            break
-    if p0 is None:
-        raise ModelError("TerraMind model has no parameters; cannot verify weights.")
-    if not torch.isfinite(p0).all():
-        raise ModelError("TerraMind parameters contain NaN/Inf; load likely failed.")
+    wstats = verify_loaded_params(model, model_name="TerraMind")
 
-    p0f = p0.float()
     meta = {
         "model_key": str(model_key),
         "pretrained": bool(pretrained),
         "modality": str(modality),
         "device": str(dev),
-        "param_mean": float(p0f.mean().cpu()),
-        "param_std": float(p0f.std().cpu()),
-        "param_absmax": float(p0f.abs().max().cpu()),
+        **wstats,
     }
     return model, meta
 
@@ -897,17 +859,7 @@ class TerraMindEmbedder(EmbedderBase):
                 "grid_shape": tuple(grid.shape),
                 "cls_removed": bool(cls_removed),
             }
-            da = xr.DataArray(
-                grid.astype(np.float32),
-                dims=("d", "y", "x"),
-                coords={
-                    "d": np.arange(grid.shape[0]),
-                    "y": np.arange(grid.shape[1]),
-                    "x": np.arange(grid.shape[2]),
-                },
-                name="embedding",
-                attrs=gmeta,
-            )
+            da = grid_to_dataarray(grid.astype(np.float32), meta=gmeta)
             return Embedding(data=da, meta=gmeta)
 
         raise ModelError(f"Unknown output mode: {output.mode}")

--- a/src/rs_embed/embedders/onthefly_thor.py
+++ b/src/rs_embed/embedders/onthefly_thor.py
@@ -7,7 +7,6 @@ from functools import lru_cache
 from typing import Any
 
 import numpy as np
-import xarray as xr
 
 from ..core.embedding import Embedding
 from ..core.errors import ModelError
@@ -54,6 +53,7 @@ from ..tools.spatial import FULL_WINDOW, square_spatial
 from .base import EmbedderBase
 from .config import model_config_value
 from .meta import build_meta, temporal_to_range
+from .shared import grid_to_dataarray, pool_from_tokens, tokens_to_grid_dhw, verify_loaded_params
 
 
 def ensure_torch() -> None:
@@ -61,32 +61,6 @@ def ensure_torch() -> None:
         import torch  # noqa: F401
     except Exception as e:
         raise ModelError("This embedder requires torch installed.") from e
-
-
-def pool_from_tokens(tokens, pooling):
-    n = len(tokens)
-    h2 = int((n - 1) ** 0.5)
-    has_cls = n > 1 and h2 * h2 == n - 1
-    patch = tokens[1:] if has_cls else tokens
-    if len(patch) == 0:
-        return tokens[0].astype("float32"), has_cls
-    if pooling == "mean":
-        return patch.mean(axis=0).astype("float32"), has_cls
-    if pooling == "max":
-        return patch.max(axis=0).astype("float32"), has_cls
-    raise ModelError(f"Unknown pooling={pooling!r} (expected 'mean' or 'max').")
-
-
-def tokens_to_grid_dhw(tokens):
-    n = len(tokens)
-    h2 = int((n - 1) ** 0.5)
-    has_cls = n > 1 and h2 * h2 == n - 1
-    patch = tokens[1:] if has_cls else tokens
-    p, d = patch.shape
-    hw = int(p**0.5)
-    if hw * hw != p:
-        raise ModelError(f"Patch token count {p} is not a perfect square.")
-    return patch.reshape(hw, hw, d).transpose(2, 0, 1).astype("float32"), (hw, hw), has_cls
 
 
 _S2_SR_10_BANDS = ["B2", "B3", "B4", "B5", "B6", "B7", "B8", "B8A", "B11", "B12"]
@@ -796,7 +770,6 @@ def _load_thor_cached(
     dev: str,
 ) -> tuple[Any, dict[str, Any]]:
     ensure_torch()
-    import torch
 
     try:
         mod = _load_thor_module()
@@ -828,17 +801,8 @@ def _load_thor_cached(
 
     model = _move_model_to_device(model, dev, model_name="THOR")
 
-    p0 = None
-    for _, p in model.named_parameters():
-        if p is not None and p.numel() > 0:
-            p0 = p.detach()
-            break
-    if p0 is None:
-        raise ModelError("THOR model has no parameters; cannot verify weights.")
-    if not torch.isfinite(p0).all():
-        raise ModelError("THOR parameters contain NaN/Inf; load likely failed.")
+    wstats = verify_loaded_params(model, model_name="THOR")
 
-    p0f = p0.float()
     out_channels = getattr(model, "out_channels", None)
     embed_dim = None
     if isinstance(out_channels, (list, tuple)) and len(out_channels) > 0:
@@ -856,9 +820,7 @@ def _load_thor_cached(
         "pretrained": bool(pretrained),
         "ckpt_path": os.path.expanduser(str(ckpt_path)) if ckpt_path else None,
         "embed_dim": embed_dim,
-        "param_mean": float(p0f.mean().cpu()),
-        "param_std": float(p0f.std().cpu()),
-        "param_absmax": float(p0f.abs().max().cpu()),
+        **wstats,
     }
     return model, meta
 
@@ -1393,17 +1355,7 @@ class THORBaseEmbedder(EmbedderBase):
                 **meta,
                 "grid_shape": tuple(grid.shape),
             }
-            da = xr.DataArray(
-                grid.astype(np.float32),
-                dims=("d", "y", "x"),
-                coords={
-                    "d": np.arange(grid.shape[0]),
-                    "y": np.arange(grid.shape[1]),
-                    "x": np.arange(grid.shape[2]),
-                },
-                name="embedding",
-                attrs=gmeta,
-            )
+            da = grid_to_dataarray(grid.astype(np.float32), meta=gmeta)
             return Embedding(data=da, meta=gmeta)
 
         raise ModelError(f"Unknown output mode: {output.mode}")

--- a/src/rs_embed/embedders/onthefly_wildsat.py
+++ b/src/rs_embed/embedders/onthefly_wildsat.py
@@ -9,7 +9,6 @@ from functools import lru_cache
 from typing import Any
 
 import numpy as np
-import xarray as xr
 
 from ..core.embedding import Embedding
 from ..core.errors import ModelError
@@ -49,6 +48,7 @@ from ..tools.spatial import square_spatial
 from .base import EmbedderBase
 from .config import model_config_value
 from .meta import build_meta, temporal_to_range
+from .shared import grid_to_dataarray, pool_from_tokens, tokens_to_grid_dhw, verify_loaded_params
 
 
 def ensure_torch() -> None:
@@ -65,32 +65,6 @@ def resize_rgb_u8(rgb_u8, out_size):
         return rgb_u8
     im = Image.fromarray(rgb_u8, mode="RGB")
     return np.array(im.resize((out_size, out_size), resample=Image.BICUBIC), dtype=np.uint8)
-
-
-def pool_from_tokens(tokens, pooling):
-    n = len(tokens)
-    h2 = int((n - 1) ** 0.5)
-    has_cls = n > 1 and h2 * h2 == n - 1
-    patch = tokens[1:] if has_cls else tokens
-    if len(patch) == 0:
-        return tokens[0].astype("float32"), has_cls
-    if pooling == "mean":
-        return patch.mean(axis=0).astype("float32"), has_cls
-    if pooling == "max":
-        return patch.max(axis=0).astype("float32"), has_cls
-    raise ModelError(f"Unknown pooling={pooling!r} (expected 'mean' or 'max').")
-
-
-def tokens_to_grid_dhw(tokens):
-    n = len(tokens)
-    h2 = int((n - 1) ** 0.5)
-    has_cls = n > 1 and h2 * h2 == n - 1
-    patch = tokens[1:] if has_cls else tokens
-    p, d = patch.shape
-    hw = int(p**0.5)
-    if hw * hw != p:
-        raise ModelError(f"Patch token count {p} is not a perfect square.")
-    return patch.reshape(hw, hw, d).transpose(2, 0, 1).astype("float32"), (hw, hw), has_cls
 
 
 _SUPPORTED_ARCHES = {"vitb16", "resnet50", "swint"}
@@ -574,18 +548,12 @@ def _load_wildsat_cached(
     if image_head is not None:
         image_head = _move_model_to_device(image_head, dev, model_name="WildSAT image head")
 
-    p0 = None
-    for _, p0cand in backbone.named_parameters():
-        if p0cand is not None and p0cand.numel() > 0:
-            p0 = p0cand.detach()
-            break
-    if p0 is None:
-        raise ModelError("WildSAT backbone has no parameters; cannot verify checkpoint load.")
-    if not torch.isfinite(p0).all():
-        raise ModelError(
-            "WildSAT backbone parameters contain NaN/Inf; checkpoint load likely failed."
-        )
-    p0f = p0.float()
+    wstats = verify_loaded_params(
+        backbone,
+        model_name="WildSAT",
+        no_params_msg="WildSAT backbone has no parameters; cannot verify checkpoint load.",
+        nonfinite_msg="WildSAT backbone parameters contain NaN/Inf; checkpoint load likely failed.",
+    )
 
     meta = {
         "ckpt_path": p,
@@ -598,9 +566,7 @@ def _load_wildsat_cached(
         "backbone_loaded_keys": int(loaded_count),
         "backbone_missing_keys": int(len(getattr(msg, "missing_keys", []))),
         "backbone_unexpected_keys": int(len(getattr(msg, "unexpected_keys", []))),
-        "param_mean": float(p0f.mean().cpu()),
-        "param_std": float(p0f.std().cpu()),
-        "param_absmax": float(p0f.abs().max().cpu()),
+        **wstats,
         **head_meta,
     }
     return backbone, image_head, meta
@@ -1115,17 +1081,7 @@ class WildSATEmbedder(EmbedderBase):
                 "grid_shape": tuple(grid.shape),
                 "grid_hw": (int(grid.shape[1]), int(grid.shape[2])),
             }
-            da = xr.DataArray(
-                grid.astype(np.float32),
-                dims=("d", "y", "x"),
-                coords={
-                    "d": np.arange(grid.shape[0]),
-                    "y": np.arange(grid.shape[1]),
-                    "x": np.arange(grid.shape[2]),
-                },
-                name="embedding",
-                attrs=gmeta,
-            )
+            da = grid_to_dataarray(grid.astype(np.float32), meta=gmeta)
             return Embedding(data=da, meta=gmeta)
 
         raise ModelError(f"Unknown output mode: {output.mode}")
@@ -1337,17 +1293,7 @@ class WildSATEmbedder(EmbedderBase):
                     "grid_shape": tuple(grid.shape),
                     "grid_hw": (int(grid.shape[1]), int(grid.shape[2])),
                 }
-                da = xr.DataArray(
-                    grid.astype(np.float32),
-                    dims=("d", "y", "x"),
-                    coords={
-                        "d": np.arange(grid.shape[0]),
-                        "y": np.arange(grid.shape[1]),
-                        "x": np.arange(grid.shape[2]),
-                    },
-                    name="embedding",
-                    attrs=gmeta,
-                )
+                da = grid_to_dataarray(grid.astype(np.float32), meta=gmeta)
                 embeddings.append(Embedding(data=da, meta=gmeta))
             else:
                 raise ModelError(f"Unknown output mode: {output.mode}")

--- a/src/rs_embed/embedders/precomputed_copernicus_embed.py
+++ b/src/rs_embed/embedders/precomputed_copernicus_embed.py
@@ -23,6 +23,7 @@ from ._vendor.copernicus_embed import CopernicusEmbedGeoTiff
 from .base import EmbedderBase
 from .config import model_config_value
 from .meta import build_meta
+from .shared import grid_to_dataarray
 
 SUPPORTED_YEARS = {2021}
 _COPERNICUS_PROJECTION_WARNED = False
@@ -281,22 +282,7 @@ class CopernicusEmbedder(EmbedderBase):
             return Embedding(data=vec, meta=meta)
 
         if output.mode == "grid":
-            try:
-                import xarray as xr
-            except Exception as e:
-                raise ModelError("grid output requires xarray. Install: pip install xarray") from e
-
-            da = xr.DataArray(
-                chw,
-                dims=("d", "y", "x"),
-                coords={
-                    "d": np.arange(chw.shape[0]),
-                    "y": np.arange(chw.shape[1]),
-                    "x": np.arange(chw.shape[2]),
-                },
-                name="embedding",
-                attrs=meta,
-            )
+            da = grid_to_dataarray(chw, meta=meta)
             return Embedding(data=da, meta=meta)
 
         raise ModelError(f"Unknown output mode: {output.mode}")

--- a/src/rs_embed/embedders/shared.py
+++ b/src/rs_embed/embedders/shared.py
@@ -1,0 +1,164 @@
+"""Shared numeric/output helpers for embedder implementations.
+
+Verbatim-extracted from the on-the-fly embedders (M10-a): ViT token pooling
+and grid reshaping, loaded-weight sanity stats, Hugging Face cache-dir
+resolution, Sentinel-2 reflectance normalization, and xarray grid output
+construction. Behavior is intentionally identical to the previous per-file
+copies; model-specific wording is parameterized, never rewritten.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import numpy as np
+
+from ..core.errors import ModelError
+
+
+def pool_from_tokens(tokens, pooling):
+    """Pool ViT patch tokens [N,D] -> (vec [D], cls_removed). Excludes CLS if present."""
+    n = len(tokens)
+    h2 = int((n - 1) ** 0.5)
+    has_cls = n > 1 and h2 * h2 == n - 1
+    patch = tokens[1:] if has_cls else tokens
+    if len(patch) == 0:
+        return tokens[0].astype("float32"), has_cls
+    if pooling == "mean":
+        return patch.mean(axis=0).astype("float32"), has_cls
+    if pooling == "max":
+        return patch.max(axis=0).astype("float32"), has_cls
+    raise ModelError(f"Unknown pooling={pooling!r} (expected 'mean' or 'max').")
+
+
+def tokens_to_grid_dhw(tokens):
+    """Reshape ViT patch tokens [N,D] -> (grid [D,h,w], (h,w), cls_removed)."""
+    n = len(tokens)
+    h2 = int((n - 1) ** 0.5)
+    has_cls = n > 1 and h2 * h2 == n - 1
+    patch = tokens[1:] if has_cls else tokens
+    p, d = patch.shape
+    hw = int(p**0.5)
+    if hw * hw != p:
+        raise ModelError(f"Patch token count {p} is not a perfect square.")
+    return patch.reshape(hw, hw, d).transpose(2, 0, 1).astype("float32"), (hw, hw), has_cls
+
+
+def verify_loaded_params(
+    model: Any,
+    *,
+    model_name: str,
+    no_params_msg: str | None = None,
+    nonfinite_msg: str | None = None,
+    check_near_zero: bool = False,
+) -> dict[str, float]:
+    """Sanity stats over the first non-empty parameter of a freshly loaded model.
+
+    Returns ``{"param_mean", "param_std", "param_absmax"}``. Raises ModelError when
+    the model has no parameters, the parameter contains NaN/Inf, or (with
+    ``check_near_zero``) the stats look uninitialized. Message overrides exist so
+    each caller keeps its historical wording exactly.
+    """
+    import torch
+
+    p0 = None
+    for _, p in model.named_parameters():
+        if p is not None and p.numel() > 0:
+            p0 = p.detach()
+            break
+    if p0 is None:
+        raise ModelError(
+            no_params_msg or f"{model_name} model has no parameters; cannot verify weights."
+        )
+    if not torch.isfinite(p0).all():
+        raise ModelError(
+            nonfinite_msg or f"{model_name} parameters contain NaN/Inf; load likely failed."
+        )
+
+    p0f = p0.float()
+    stats = {
+        "param_mean": float(p0f.mean().cpu()),
+        "param_std": float(p0f.std().cpu()),
+        "param_absmax": float(p0f.abs().max().cpu()),
+    }
+    if check_near_zero and stats["param_std"] < 1e-6 and stats["param_absmax"] < 1e-5:
+        raise ModelError(f"{model_name} parameters look uninitialized (near-zero stats).")
+    return stats
+
+
+def resolve_hf_cache_dir() -> str | None:
+    """Hugging Face cache dir from the env chain HUGGINGFACE_HUB_CACHE > HF_HOME > HUGGINGFACE_HOME."""
+    return (
+        os.environ.get("HUGGINGFACE_HUB_CACHE")
+        or os.environ.get("HF_HOME")
+        or os.environ.get("HUGGINGFACE_HOME")
+    )
+
+
+def normalize_s2(
+    raw: np.ndarray,
+    *,
+    mode: str,
+    model_name: str,
+    modes_hint: str,
+    allow_tchw: bool = False,
+) -> np.ndarray:
+    """Clip S2 SR values to [0, 10000] and apply unit_scale / per_tile_minmax / none.
+
+    ``allow_tchw`` enables the TCHW input guard and per-frame minmax axes; without
+    it the input is treated as CHW (minmax over the trailing two axes of a 3D array).
+    """
+    x = np.asarray(raw, dtype=np.float32)
+    if allow_tchw and x.ndim not in {3, 4}:
+        raise ModelError(f"{model_name} normalization expects CHW or TCHW, got {x.shape}")
+    x = np.nan_to_num(x, nan=0.0, posinf=0.0, neginf=0.0)
+    x = np.clip(x, 0.0, 10000.0)
+
+    m = str(mode).lower().strip()
+    if m in {"unit", "unit_scale", "reflectance"}:
+        x = x / 10000.0
+    elif m in {"per_tile_minmax", "minmax", "tile_minmax"}:
+        x = x / 10000.0
+        if allow_tchw and x.ndim == 4:
+            lo = np.min(x, axis=(2, 3), keepdims=True)
+            hi = np.max(x, axis=(2, 3), keepdims=True)
+        else:
+            lo = np.min(x, axis=(1, 2), keepdims=True)
+            hi = np.max(x, axis=(1, 2), keepdims=True)
+        den = np.maximum(hi - lo, 1e-6)
+        x = (x - lo) / den
+    elif m in {"none", "raw"}:
+        pass
+    else:
+        raise ModelError(
+            f"Unknown {model_name} normalization mode '{mode}'. Use one of: {modes_hint}."
+        )
+    return np.nan_to_num(x, nan=0.0, posinf=0.0, neginf=0.0).astype(np.float32)
+
+
+def import_xarray():
+    """Import xarray lazily; grid output is the only path that needs it."""
+    try:
+        import xarray as xr
+    except Exception as e:
+        raise ModelError("grid output requires xarray. Install: pip install xarray") from e
+    return xr
+
+
+def grid_to_dataarray(grid: np.ndarray, *, meta: dict[str, Any], coords_d=None):
+    """Wrap a [D,y,x] grid as the standard embedding DataArray (arange coords)."""
+    xr = import_xarray()
+    if coords_d is None:
+        coords_d = np.arange(grid.shape[0])
+    return xr.DataArray(
+        grid,
+        dims=("d", "y", "x"),
+        coords={
+            "d": coords_d,
+            "y": np.arange(grid.shape[1]),
+            "x": np.arange(grid.shape[2]),
+        },
+        name="embedding",
+        attrs=meta,
+    )

--- a/tests/test_anysat_output_modes.py
+++ b/tests/test_anysat_output_modes.py
@@ -4,7 +4,13 @@ from contextlib import nullcontext
 
 import numpy as np
 
-if "xarray" not in sys.modules:
+try:
+    import xarray  # noqa: F401
+except ImportError:
+    # Environments without xarray: a minimal stand-in is enough for these tests.
+    # (A SimpleNamespace has no __spec__, so only install it when the real
+    # package is genuinely unavailable — otherwise it poisons later imports
+    # that probe sys.modules, e.g. torch._dynamo's find_spec calls.)
 
     class _FakeDataArray:
         def __init__(self, data, dims=None, coords=None, name=None, attrs=None):


### PR DESCRIPTION
Batch M10-a: verbatim-duplicated helpers across embedders → one shared module. **Zero numeric/behavioral change** (only textually-identical copies unified; drifted copies parameterized to preserve each caller's exact output, or left + reported). **First of a 3-PR stack — merge in order: M10-a → M1 → M10-b.**

- `pool_from_tokens` / `tokens_to_grid_dhw`: 8 byte-identical copies → `embedders/shared.py` (old names stay importable).
- `base_meta`: 6 identical copies → one impl in `embedders/meta.py`.
- Weight-stats verification: 12 sites → `verify_loaded_params(...)` (historical error strings preserved per-site).
- HF cache-dir chain → `resolve_hf_cache_dir()`.
- galileo/fomo `_normalize_s2` → parameterized `normalize_s2(...)` (numerically verified bit-identical; thor/agrifm variants left — different guards/stats).
- `xr.DataArray` grid construction: 29 of 31 sites → `grid_to_dataarray(...)` (gse band-name coords + tessera's distinct error left).

Net **−670 LOC**. Full suite 1027 passed, 4 skipped; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)