### PR TITLE
refactor: merge paired forwards and unify fetch fan-out (M10-b, partial)

### DIFF
--- a/src/rs_embed/embedders/onthefly_fomo.py
+++ b/src/rs_embed/embedders/onthefly_fomo.py
@@ -472,7 +472,7 @@ def _tokens_to_grid(
     expected_per_mod = expected_gs * expected_gs if expected_gs > 0 else 0
     expected_tokens = n_modalities * expected_per_mod
 
-    if n_modalities <= 0 or n_tokens % n_modalities != 0:
+    def _vector_as_1x1() -> tuple[np.ndarray, dict[str, Any]]:
         vec = np.mean(tokens_nd, axis=0).astype(np.float32)
         return vec[:, None, None], {
             "grid_kind": "vector_as_1x1",
@@ -481,16 +481,13 @@ def _tokens_to_grid(
             "grid_expected_tokens": int(expected_tokens),
         }
 
+    if n_modalities <= 0 or n_tokens % n_modalities != 0:
+        return _vector_as_1x1()
+
     per_mod = n_tokens // n_modalities
     gs = int(round(float(per_mod) ** 0.5))
     if gs * gs != per_mod:
-        vec = np.mean(tokens_nd, axis=0).astype(np.float32)
-        return vec[:, None, None], {
-            "grid_kind": "vector_as_1x1",
-            "grid_hw": (1, 1),
-            "grid_shape": (int(vec.shape[0]), 1, 1),
-            "grid_expected_tokens": int(expected_tokens),
-        }
+        return _vector_as_1x1()
 
     toks = tokens_nd.reshape(n_modalities, gs, gs, dim)  # [K,H,W,D]
     grid = toks.mean(axis=0).transpose(2, 0, 1).astype(np.float32)  # [D,H,W]

--- a/src/rs_embed/embedders/onthefly_olmoearth.py
+++ b/src/rs_embed/embedders/onthefly_olmoearth.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import warnings
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import lru_cache
 from typing import Any
 
@@ -36,6 +35,7 @@ from ..providers.resolution import is_provider_backend
 from ..tools.runtime import load_cached_with_device as _load_cached_with_device
 from ..tools.shape import (
     crop_grid_to_roi,
+    parallel_indexed_fetch,
     prepare_square,
     roi_fetch_meta,
     roi_is_full,
@@ -1176,27 +1176,23 @@ class OlmoEarthEmbedder(EmbedderBase):
         geo_rois: list[tuple[float, float, float, float] | None] = [None] * n
 
         def _fetch_one(
-            i: int, sp: SpatialSpec
-        ) -> tuple[int, np.ndarray, tuple[float, float, float, float] | None]:
+            i: int,
+        ) -> tuple[np.ndarray, tuple[float, float, float, float] | None]:
             fr = self.fetch_input(
-                provider, spatial=sp, temporal=t, sensor=sensor, temporal_mode=temporal_mode
+                provider,
+                spatial=spatials[i],
+                temporal=t,
+                sensor=sensor,
+                temporal_mode=temporal_mode,
             )
             assert fr is not None
-            return i, np.asarray(fr.data, dtype=np.float32), (fr.meta or {}).get("roi_window_geo")
+            return np.asarray(fr.data, dtype=np.float32), (fr.meta or {}).get("roi_window_geo")
 
-        mw = self._resolve_fetch_workers(n)
-        if mw == 1:
-            for i, sp in enumerate(spatials):
-                ii, raw, gr = _fetch_one(i, sp)
-                prefetched[ii] = raw
-                geo_rois[ii] = gr
-        else:
-            with ThreadPoolExecutor(max_workers=mw) as ex:
-                futs = [ex.submit(_fetch_one, i, sp) for i, sp in enumerate(spatials)]
-                for fut in as_completed(futs):
-                    ii, raw, gr = fut.result()
-                    prefetched[ii] = raw
-                    geo_rois[ii] = gr
+        for i, (raw, gr) in enumerate(
+            parallel_indexed_fetch(n, _fetch_one, max_workers=self._resolve_fetch_workers(n))
+        ):
+            prefetched[i] = raw
+            geo_rois[i] = gr
 
         raw_inputs: list[np.ndarray] = []
         for i, raw in enumerate(prefetched):

--- a/src/rs_embed/embedders/onthefly_prithvi.py
+++ b/src/rs_embed/embedders/onthefly_prithvi.py
@@ -699,17 +699,7 @@ def _prithvi_forward_tokens(
             out = model(x, temporal_coords=temporal_coords, location_coords=location_coords)
 
     # normalize output -> tokens
-    tokens = None
-    if isinstance(out, (tuple, list)):
-        tokens = out[-1]
-    elif hasattr(out, "last_hidden_state"):
-        tokens = out.last_hidden_state
-    elif isinstance(out, dict):
-        tokens = out.get("tokens") or out.get("last_hidden_state") or out.get("hidden_states")
-        if isinstance(tokens, (tuple, list)):
-            tokens = tokens[-1]
-    else:
-        tokens = out
+    tokens = _extract_tokens(out)
 
     if tokens is None:
         raise ModelError("Prithvi forward did not return tokens.")
@@ -765,17 +755,7 @@ def _prithvi_forward_tokens_batch(
         else:
             out = model(xb, temporal_coords=temporal_coords, location_coords=location_coords)
 
-    tokens = None
-    if isinstance(out, (tuple, list)):
-        tokens = out[-1]
-    elif hasattr(out, "last_hidden_state"):
-        tokens = out.last_hidden_state
-    elif isinstance(out, dict):
-        tokens = out.get("tokens") or out.get("last_hidden_state") or out.get("hidden_states")
-        if isinstance(tokens, (tuple, list)):
-            tokens = tokens[-1]
-    else:
-        tokens = out
+    tokens = _extract_tokens(out)
 
     if tokens is None:
         raise ModelError("Prithvi forward did not return tokens.")

--- a/src/rs_embed/embedders/onthefly_terrafm.py
+++ b/src/rs_embed/embedders/onthefly_terrafm.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import importlib
 import os
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import lru_cache
 from typing import Any
 
@@ -43,6 +42,7 @@ from ..tools.shape import (
     crop_grid_and_pool,
     crop_grid_to_roi,
     geo_roi_from_meta,
+    parallel_indexed_fetch,
     roi_fetch_meta,
     roi_is_full,
 )
@@ -860,10 +860,10 @@ class TerraFMBEmbedder(EmbedderBase):
         prefetched_raw: list[np.ndarray | None] = [None] * n
         prefetched_meta: list[dict[str, Any] | None] = [None] * n
 
-        def _fetch_one(i: int, sp: SpatialSpec) -> tuple[int, np.ndarray, dict[str, Any] | None]:
+        def _fetch_one(i: int) -> tuple[np.ndarray, dict[str, Any] | None]:
             # Fetch-square each ROI; the ROI window rides in the per-item meta
             # (roi_window_geo) so from_inputs crops each output back to it.
-            sq, geo_roi = square_spatial(sp)
+            sq, geo_roi = square_spatial(spatials[i])
             if modality == "s2":
                 x_chw = _fetch_s2_sr_12_chw(
                     provider,
@@ -875,7 +875,7 @@ class TerraFMBEmbedder(EmbedderBase):
                 )
                 # get_embedding(input_chw=...) expects raw S2 SR in [0..10000]
                 raw = np.clip(x_chw * 10000.0, 0.0, 10000.0).astype(np.float32)
-                return i, raw, roi_fetch_meta(geo_roi)
+                return raw, roi_fetch_meta(geo_roi)
             if modality == "s1":
                 raw, fetch_meta = _fetch_s1_vvvh_raw_chw_with_meta(
                     provider,
@@ -887,22 +887,14 @@ class TerraFMBEmbedder(EmbedderBase):
                     require_iw=s1_require_iw,
                     relax_iw_on_empty=s1_relax_iw_on_empty,
                 )
-                return i, raw, {**fetch_meta, **(roi_fetch_meta(geo_roi) or {})}
+                return raw, {**fetch_meta, **(roi_fetch_meta(geo_roi) or {})}
             raise ModelError("modality must be 's2' or 's1'.")
 
-        mw = self._resolve_fetch_workers(n)
-        if mw == 1:
-            for i, sp in enumerate(spatials):
-                ii, raw, fetch_meta = _fetch_one(i, sp)
-                prefetched_raw[ii] = raw
-                prefetched_meta[ii] = fetch_meta
-        else:
-            with ThreadPoolExecutor(max_workers=mw) as ex:
-                futs = [ex.submit(_fetch_one, i, sp) for i, sp in enumerate(spatials)]
-                for fut in as_completed(futs):
-                    i, raw, fetch_meta = fut.result()
-                    prefetched_raw[i] = raw
-                    prefetched_meta[i] = fetch_meta
+        for i, (raw, fetch_meta) in enumerate(
+            parallel_indexed_fetch(n, _fetch_one, max_workers=self._resolve_fetch_workers(n))
+        ):
+            prefetched_raw[i] = raw
+            prefetched_meta[i] = fetch_meta
 
         raw_inputs: list[np.ndarray] = []
         for i, raw in enumerate(prefetched_raw):

--- a/src/rs_embed/embedders/onthefly_terramind.py
+++ b/src/rs_embed/embedders/onthefly_terramind.py
@@ -373,60 +373,14 @@ def _terramind_forward_tokens(
     layer_index: int,
     device: str,
 ) -> tuple[np.ndarray, dict[str, Any]]:
-    ensure_torch()
-    import torch
-
-    dev = _resolve_device(device)
-    model = model.to(dev).eval()
-    x = torch.from_numpy(x_bchw.astype(np.float32, copy=False)).to(dev)
-
-    with torch.no_grad():
-        out = None
-        # Preferred path: explicit modality dict
-        try:
-            out = model({str(modality): x})
-        except Exception as _e:
-            # Fallback for wrappers that accept plain tensor
-            out = model(x)
-
-    def _pick_from_sequence(seq: Any, idx: int) -> torch.Tensor | None:
-        if not isinstance(seq, (list, tuple)) or len(seq) == 0:
-            return None
-        cand = None
-        try:
-            cand = seq[idx]
-        except Exception as _e:
-            cand = None
-        if torch.is_tensor(cand) and cand.ndim == 3:
-            return cand
-        for v in reversed(seq):
-            if torch.is_tensor(v) and v.ndim == 3:
-                return v
-        return None
-
-    toks_t = None
-    if isinstance(out, (list, tuple)):
-        toks_t = _pick_from_sequence(out, layer_index)
-    elif isinstance(out, dict):
-        vals = list(out.values())
-        toks_t = _pick_from_sequence(vals, layer_index)
-        if toks_t is None:
-            for v in vals:
-                if torch.is_tensor(v) and v.ndim == 3:
-                    toks_t = v
-                    break
-    elif hasattr(out, "last_hidden_state") and torch.is_tensor(out.last_hidden_state):
-        if out.last_hidden_state.ndim == 3:
-            toks_t = out.last_hidden_state
-    elif torch.is_tensor(out) and out.ndim == 3:
-        toks_t = out
-
-    if toks_t is None:
-        raise ModelError(
-            f"TerraMind forward did not return token tensor [B,N,D]. Got type={type(out)}."
-        )
-
-    tokens = toks_t[0].detach().float().cpu().numpy().astype(np.float32)
+    tokens_bnd, _bmeta = _terramind_forward_tokens_batch(
+        model,
+        x_bchw,
+        modality=modality,
+        layer_index=layer_index,
+        device=device,
+    )
+    tokens = tokens_bnd[0]
     meta = {
         "tokens_shape": tuple(tokens.shape),
         "layer_index": int(layer_index),
@@ -452,9 +406,11 @@ def _terramind_forward_tokens_batch(
 
     with torch.no_grad():
         out = None
+        # Preferred path: explicit modality dict
         try:
             out = model({str(modality): x})
         except Exception as _e:
+            # Fallback for wrappers that accept plain tensor
             out = model(x)
 
     def _pick_from_sequence(seq: Any, idx: int) -> torch.Tensor | None:

--- a/src/rs_embed/tools/shape.py
+++ b/src/rs_embed/tools/shape.py
@@ -315,6 +315,33 @@ def crop_grid_and_pool(
     return g, vec
 
 
+def parallel_indexed_fetch(
+    n: int,
+    fetch_one: Callable[[int], Any],
+    *,
+    max_workers: int = 1,
+) -> list[Any]:
+    """Call ``fetch_one(i)`` for ``i in range(n)`` and return results ordered by i.
+
+    Sequential when ``max_workers <= 1``; otherwise a ``ThreadPoolExecutor``
+    slots each result back into its submitted index. Exceptions raised by
+    ``fetch_one`` propagate (via ``fut.result()`` on the threaded path).
+
+    Collapses the per-model "sequential-or-threaded fan-out with index slotting"
+    boilerplate that several embedders' batch fetch loops repeat.
+    """
+    results: list[Any] = [None] * n
+    if max_workers <= 1:
+        for i in range(n):
+            results[i] = fetch_one(i)
+    else:
+        with ThreadPoolExecutor(max_workers=max_workers) as ex:
+            futs = {ex.submit(fetch_one, i): i for i in range(n)}
+            for fut in as_completed(futs):
+                results[futs[fut]] = fut.result()
+    return results
+
+
 def square_fetch_batch(
     spatials: list[SpatialSpec],
     fetch_fn: Callable[[SpatialSpec], np.ndarray],
@@ -332,24 +359,16 @@ def square_fetch_batch(
     pool boilerplate into one call. Use :func:`roi_fetch_meta` to turn each
     ``geo_rois[i]`` into the ``fetch_meta`` passed back into ``get_embedding``.
     """
-    n = len(spatials)
-    raws: list[np.ndarray | None] = [None] * n
-    geo_rois: list[tuple[float, float, float, float]] = [FULL_WINDOW] * n
 
-    def _one(i: int, sp: SpatialSpec) -> tuple[int, np.ndarray, tuple[float, float, float, float]]:
-        sq, geo_roi = square_spatial(sp)
-        return i, fetch_fn(sq), geo_roi
+    def _one(i: int) -> tuple[np.ndarray | None, tuple[float, float, float, float]]:
+        sq, geo_roi = square_spatial(spatials[i])
+        return fetch_fn(sq), geo_roi
 
-    if max_workers <= 1:
-        for i, sp in enumerate(spatials):
-            _, raws[i], geo_rois[i] = _one(i, sp)
-    else:
-        with ThreadPoolExecutor(max_workers=max_workers) as ex:
-            for fut in as_completed([ex.submit(_one, i, sp) for i, sp in enumerate(spatials)]):
-                i, raw, geo_roi = fut.result()
-                raws[i], geo_rois[i] = raw, geo_roi
+    results = parallel_indexed_fetch(len(spatials), _one, max_workers=max_workers)
+    raws = [r for r, _ in results]
+    geo_rois = [g for _, g in results]
 
     missing = [i for i, r in enumerate(raws) if r is None]
     if missing:
         raise ModelError(f"square_fetch_batch: fetch_fn returned None at indices {missing}.")
-    return [r for r in raws if r is not None], geo_rois
+    return raws, geo_rois


### PR DESCRIPTION
Batch M10-b (partial): safe, provably-equivalent embedder dedups. Stacked on #120 and the M1 PR — **merge those first.** Zero numeric change (verified by reading; suite green throughout).

**Done:**
- terramind `_terramind_forward_tokens` → delegates to batch + `[0]` (single-path meta preserved).
- prithvi forward pair → uses existing `_extract_tokens` (inline ladders were byte-equivalent).
- fomo `_tokens_to_grid` → two identical `vector_as_1x1` branches collapsed.
- New `tools.shape.parallel_indexed_fetch` captures the sequential-or-threaded fan-out + index-slotting; `square_fetch_batch`, terrafm & olmoearth batch loops use it (behavior identical incl. mw≤1 path + error propagation).

Net −60 LOC. Full suite 1030 passed, 4 skipped; ruff clean.

**Deliberately deferred (M10-b2, see MAINTAINABILITY_REVIEW.md):** the single-vs-batch OUTPUT builders (prithvi 4×, wildsat/fomo, dofa/terrafm/remoteclip/satvision) and fomo/wildsat torch forward-pair merges. Every batch test mocks `get_embedding`, so these token→output paths have **zero test coverage** — hand-merging under a zero-change mandate risks silent meta/value drift. They need dedicated equivalence tests first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)